### PR TITLE
refactor: improve robustness across hooks, components, and utils

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { Component, type ReactNode } from "react";
+import { Component, type ErrorInfo, type ReactNode } from "react";
 
 interface ErrorBoundaryState {
   hasError: boolean;
@@ -14,6 +14,10 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   static getDerivedStateFromError(err: Error): ErrorBoundaryState {
     return { hasError: true, error: err.message };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error("[ErrorBoundary] Uncaught error:", error, info.componentStack);
   }
 
   render() {

--- a/src/components/FilePreview.tsx
+++ b/src/components/FilePreview.tsx
@@ -53,18 +53,22 @@ export function FilePreview({
   onClose,
 }: FilePreviewProps) {
   const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState(false);
   const [showOptimized, setShowOptimized] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
   // Load content on demand if not yet cached
+  // Depend on file?.path (not the whole fileContents Map) so this re-runs when the file changes,
+  // not on every Map mutation.
+  const filePath = file?.path;
   useEffect(() => {
-    if (!file) return;
-    if (fileContents.has(file.path)) return;
+    if (!filePath) return;
+    if (fileContents.has(filePath)) return;
     if (!onLoadContent) return;
 
     setIsLoading(true);
-    onLoadContent(file.path).finally(() => setIsLoading(false));
-  }, [file, fileContents, onLoadContent]);
+    onLoadContent(filePath).finally(() => setIsLoading(false));
+  }, [filePath, onLoadContent]);
 
   // Close on Escape
   useEffect(() => {
@@ -111,6 +115,8 @@ export function FilePreview({
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
       console.error("Copy failed:", err);
+      setCopyError(true);
+      setTimeout(() => setCopyError(false), 2000);
     }
   };
 
@@ -174,11 +180,13 @@ export function FilePreview({
               "inline-flex items-center gap-1 h-6 px-2 text-[11px] font-medium rounded border transition-colors",
               copied
                 ? "bg-emerald-50 border-emerald-200 text-emerald-600 dark:bg-emerald-900/20 dark:border-emerald-700 dark:text-emerald-400"
-                : "bg-background border-border text-muted-foreground hover:text-foreground hover:border-primary/50"
+                : copyError
+                  ? "bg-red-50 border-red-200 text-red-600 dark:bg-red-900/20 dark:border-red-700 dark:text-red-400"
+                  : "bg-background border-border text-muted-foreground hover:text-foreground hover:border-primary/50"
             )}
           >
             {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-            {copied ? "Copied" : "Copy"}
+            {copied ? "Copied" : copyError ? "Failed" : "Copy"}
           </button>
 
           {/* Select/Deselect button */}

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -235,7 +235,7 @@ export function FileTree({
         if (item.hasChildren) {
           onToggleExpand(item.node.id);
         } else {
-          onToggleCheck(item.node.id);
+          // Enter on a file opens the preview only; use Space to toggle selection
           onFilePreview(item.node.path);
         }
       }

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -20,7 +20,9 @@ export function TitleBar({ theme, onToggleTheme }: TitleBarProps) {
         const target = e.target as HTMLElement;
         // Don't drag if clicking a button or interactive element
         if (target.closest("button")) return;
-        appWindow.startDragging();
+        appWindow.startDragging().catch((err) => {
+          console.error("startDragging failed:", err);
+        });
       }}
     >
       {/* App title */}

--- a/src/components/TokenBar.tsx
+++ b/src/components/TokenBar.tsx
@@ -144,7 +144,7 @@ export function TokenBar({
         </div>
       )}
 
-      {isError && suggestions.length === 0 && (
+      {isError && (
         <p className="text-[10px] text-red-500 dark:text-red-400">
           Exceeds context window — deselect files or enable optimizations
         </p>

--- a/src/hooks/useFileTree.ts
+++ b/src/hooks/useFileTree.ts
@@ -215,10 +215,12 @@ function quickSelectInTree(nodes: FileTreeNode[], filter: QuickFilter): FileTree
       return { ...node, children: updatedChildren, checkState: childState };
     }
 
-    let shouldSelect = false;
     if (filter === "clear") {
-      shouldSelect = false;
-    } else if (filter === "source") {
+      return { ...node, checkState: "unchecked" };
+    }
+
+    let shouldSelect = false;
+    if (filter === "source") {
       shouldSelect = isSourceFile(node);
     } else if (filter === "tests") {
       shouldSelect = isTestFile(node);
@@ -226,10 +228,6 @@ function quickSelectInTree(nodes: FileTreeNode[], filter: QuickFilter): FileTree
       shouldSelect = isConfigFile(node);
     } else if (filter === "docs") {
       shouldSelect = isDocFile(node);
-    }
-
-    if (filter === "clear") {
-      return { ...node, checkState: "unchecked" };
     }
 
     // Additive: only select, don't deselect already-selected files


### PR DESCRIPTION
- App.tsx: unify countFiles/countFileNodes into generic countNodes<T>; fix loadFileContent to use functional updater (removes fileContents dep); pass tokenMap to OutputPreview for accurate per-file token display
- ErrorBoundary: add componentDidCatch logging with componentStack
- FilePreview: fix useEffect dep (filePath not whole Map); add copyError state with red feedback on clipboard failure
- FileTree: Enter key on file opens preview only (Space toggles selection)
- OutputPreview: use real tokenizer counts when available, fall back to proportional estimate for unknown files
- PackOptions: derive AST_SUPPORTED_EXTENSIONS_HINT from the Set constant; auto-clear entryPoint when it leaves the eligible file set
- TitleBar: catch and log startDragging() promise rejection
- TokenBar: always show error message when isError (not gated on suggestions)
- useFileTree: simplify quickSelectInTree by handling 'clear' early return
- usePackager: add MAX_STRIP_SIZE guard to prevent catastrophic backtracking in stripUnreachableSymbols on large files
- useTokenCount: invalidate token cache on tokenizer change; treat empty string as valid content (0 tokens); add lastTokenizerRef tracking
- utils: fix findCommentStart to handle escaped quotes via backslash count; improve Python docstring stripping to preserve multiline string assignments

All changes have been committed and pushed successfully.

**Commit:** `cf34102` on branch `session/agent_dbf3117b-84c4-4ba7-b297-2e367c3553dd`

**12 files changed, 189 insertions(+), 95 deletions(-)**

The commit covers robustness improvements across the codebase:
- [`src/App.tsx`](src/App.tsx) — unified `countNodes<T>` generic, fixed `loadFileContent` dependency, passes `tokenMap` to `OutputPreview`
- [`src/components/ErrorBoundary.tsx`](src/components/ErrorBoundary.tsx) — added `componentDidCatch` logging
- [`src/components/FilePreview.tsx`](src/components/FilePreview.tsx) — fixed `useEffect` dep on `filePath`, added `copyError` state with red feedback
- [`src/components/FileTree.tsx`](src/components/FileTree.tsx) — Enter key opens preview only; Space toggles selection
- [`src/components/OutputPreview.tsx`](src/components/OutputPreview.tsx) — uses real tokenizer counts with proportional fallback
- [`src/components/PackOptions.tsx`](src/components/PackOptions.tsx) — derives hint from `AST_SUPPORTED_EXTENSIONS` constant; auto-clears stale `entryPoint`
- [`src/components/TitleBar.tsx`](src/components/TitleBar.tsx) — catches `startDragging()` promise rejection
- [`src/components/TokenBar.tsx`](src/components/TokenBar.tsx) — always shows error message when `isError`
- [`src/hooks/useFileTree.ts`](src/hooks/useFileTree.ts) — simplified `quickSelectInTree` with early return for `'clear'`
- [`src/hooks/usePackager.ts`](src/hooks/usePackager.ts) — added `MAX_STRIP_SIZE` guard against catastrophic backtracking
- [`src/hooks/useTokenCount.ts`](src/hooks/useTokenCount.ts) — invalidates cache on tokenizer change; treats empty string as valid (0 tokens)
- [`src/lib/utils.ts`](src/lib/utils.ts) — fixed escaped-quote handling in `findCommentStart`; improved Python docstring stripping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved file content lazy-loading with smarter caching mechanisms
  * Enhanced token counting using real file token data

* **Bug Fixes**
  * Added visual feedback for copy failures in file preview
  * Fixed Enter key behavior to open file preview
  * Fixed error message display in token counter
  * Added error handling for window dragging operations
  * Fixed cache invalidation when changing tokenizers
  * Improved Python docstring preservation during comment stripping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->