### PR TITLE
fix(ast): Fix AST bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -79,13 +79,13 @@ jobs:
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ needs.semantic-release.outputs.tag }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.minimax

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ dist-ssr
 *.sln
 *.sw?
 .minimax
+.env.build

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ Bablusheed is a Tauri + React desktop app that packs repositories into LLM-frien
 - Lets you open a project and select files quickly (`Source`, `Tests`, `Config`, `Docs`, custom filters).
 - Estimates tokens per file and in total for the selected LLM profile.
 - Packs selected files into `N` output packs (`Plain` or `Markdown`).
-- Exports individual packs, or exports all packs in one folder operation.
-- Adds optional prompt scaffolding for easier upload to ChatGPT/Claude/Gemini/etc.
+- Exports all packs in one folder operation.
 
 ## Optimization Features
 

--- a/biome.json
+++ b/biome.json
@@ -65,7 +65,7 @@
       "style": {
         "useBlockStatements": {
           "fix": "safe",
-          "level": "off",
+          "level": "warn",
           "options": {}
         },
         "useImportType": "error",

--- a/bun.lock
+++ b/bun.lock
@@ -97,23 +97,23 @@
 
     "@base-ui/utils": ["@base-ui/utils@0.2.5", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-oYC7w0gp76RI5MxprlGLV0wze0SErZaRl3AAkeP3OnNB/UBMb6RqNf6ZSIlxOc9Qp68Ab3C2VOcJQyRs7Xc7Vw=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.4", "@biomejs/cli-darwin-x64": "2.4.4", "@biomejs/cli-linux-arm64": "2.4.4", "@biomejs/cli-linux-arm64-musl": "2.4.4", "@biomejs/cli-linux-x64": "2.4.4", "@biomejs/cli-linux-x64-musl": "2.4.4", "@biomejs/cli-win32-arm64": "2.4.4", "@biomejs/cli-win32-x64": "2.4.4" }, "bin": { "biome": "bin/biome" } }, "sha512-tigwWS5KfJf0cABVd52NVaXyAVv4qpUXOWJ1rxFL8xF1RVoeS2q/LK+FHgYoKMclJCuRoCWAPy1IXaN9/mS61Q=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.5", "@biomejs/cli-darwin-x64": "2.4.5", "@biomejs/cli-linux-arm64": "2.4.5", "@biomejs/cli-linux-arm64-musl": "2.4.5", "@biomejs/cli-linux-x64": "2.4.5", "@biomejs/cli-linux-x64-musl": "2.4.5", "@biomejs/cli-win32-arm64": "2.4.5", "@biomejs/cli-win32-x64": "2.4.5" }, "bin": { "biome": "bin/biome" } }, "sha512-OWNCyMS0Q011R6YifXNOg6qsOg64IVc7XX6SqGsrGszPbkVCoaO7Sr/lISFnXZ9hjQhDewwZ40789QmrG0GYgQ=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jZ+Xc6qvD6tTH5jM6eKX44dcbyNqJHssfl2nnwT6vma6B1sj7ZLTGIk6N5QwVBs5xGN52r3trk5fgd3sQ9We9A=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-lGS4Nd5O3KQJ6TeWv10mElnx1phERhBxqGP/IKq0SvZl78kcWDFMaTtVK+w3v3lusRFxJY78n07PbKplirsU5g=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-Dh1a/+W+SUCXhEdL7TiX3ArPTFCQKJTI1mGncZNWfO+6suk+gYA4lNyJcBB+pwvF49uw0pEbUS49BgYOY4hzUg=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-6MoH4tyISIBNkZ2Q5T1R7dLd5BsITb2yhhhrU9jHZxnNSNMWl+s2Mxu7NBF8Y3a7JJcqq9nsk8i637z4gqkJxQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-V/NFfbWhsUU6w+m5WYbBenlEAz8eYnSqRMDMAW3K+3v0tYVkNyZn8VU0XPxk/lOqNXLSCCrV7FmV/u3SjCBShg=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-U1GAG6FTjhAO04MyH4xn23wRNBkT6H7NentHh+8UxD6ShXKBm5SY4RedKJzkUThANxb9rUKIPc7B8ew9Xo/cWg=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-+sPAXq3bxmFwhVFJnSwkSF5Rw2ZAJMH3MF6C9IveAEOdSpgajPhoQhbbAK12SehN9j2QrHpk4J/cHsa/HqWaYQ=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-iqLDgpzobG7gpBF0fwEVS/LT8kmN7+S0E2YKFDtqliJfzNLnAiV2Nnyb+ehCDCJgAZBASkYHR2o60VQWikpqIg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.4", "", { "os": "linux", "cpu": "x64" }, "sha512-R4+ZCDtG9kHArasyBO+UBD6jr/FcFCTH8QkNTOCu0pRJzCWyWC4EtZa2AmUZB5h3e0jD7bRV2KvrENcf8rndBg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.5", "", { "os": "linux", "cpu": "x64" }, "sha512-NdODlSugMzTlENPTa4z0xB82dTUlCpsrOxc43///aNkTLblIYH4XpYflBbf5ySlQuP8AA4AZd1qXhV07IdrHdQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gGvFTGpOIQDb5CQ2VC0n9Z2UEqlP46c4aNgHmAMytYieTGEcfqhfCFnhs6xjt0S3igE6q5GLuIXtdQt3Izok+g=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.5", "", { "os": "linux", "cpu": "x64" }, "sha512-NlKa7GpbQmNhZf9kakQeddqZyT7itN7jjWdakELeXyTU3pg/83fTysRRDPJD0akTfKDl6vZYNT9Zqn4MYZVBOA=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-trzCqM7x+Gn832zZHgr28JoYagQNX4CZkUZhMUac2YxvvyDRLJDrb5m9IA7CaZLlX6lTQmADVfLEKP1et1Ma4Q=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-EBfrTqRIWOFSd7CQb/0ttjHMR88zm3hGravnDwUA9wHAaCAYsULKDebWcN5RmrEo1KBtl/gDVJMrFjNR0pdGUw=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.4", "", { "os": "win32", "cpu": "x64" }, "sha512-gnOHKVPFAAPrpoPt2t+Q6FZ7RPry/FDV3GcpU53P3PtLNnQjBmKyN2Vh/JtqXet+H4pme8CC76rScwdjDcT1/A=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.5", "", { "os": "win32", "cpu": "x64" }, "sha512-Pmhv9zT95YzECfjEHNl3mN9Vhusw9VA5KHY0ZvlGsxsjwS5cb7vpRnHzJIv0vG7jB0JI7xEaMH9ddfZm/RozBw=="],
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
@@ -657,7 +657,7 @@
 
     "lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
-    "lucide-react": ["lucide-react@0.575.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg=="],
+    "lucide-react": ["lucide-react@0.576.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/docs/macos-build-signing.md
+++ b/docs/macos-build-signing.md
@@ -1,0 +1,153 @@
+# macOS Build + Signing Guide
+
+This guide is for building distributable macOS bundles for this repository (`Bablusheed`) with Tauri v2.
+
+It is aligned with:
+- Tauri v2 prerequisites and signing/notarization docs (last updated January 30, 2026)
+- current repo scripts/workflow (`bun run tauri`, `.github/workflows/release.yml`)
+
+## 1) Prerequisites
+
+Install Xcode Command Line Tools:
+
+```bash
+xcode-select --install
+xcode-select -p
+```
+
+Install Rust targets for universal builds:
+
+```bash
+rustup target add x86_64-apple-darwin aarch64-apple-darwin
+rustup target list --installed | grep apple-darwin
+```
+
+## 2) Apple Developer Setup
+
+1. Join the [Apple Developer Program](https://developer.apple.com/programs/).
+2. Create a `Developer ID Application` certificate in your Apple Developer account.
+3. Install the certificate in your login keychain.
+4. Confirm your signing identity:
+
+```bash
+security find-identity -v -p codesigning
+```
+
+You should see an identity similar to:
+`Developer ID Application: Your Name (TEAMID)`.
+
+## 3) Notarization Credentials (Choose One)
+
+Tauri supports two notarization credential methods.
+
+### Option A: App Store Connect API key
+
+Set:
+- `APPLE_API_ISSUER`
+- `APPLE_API_KEY` (Key ID)
+- `APPLE_API_KEY_PATH` (path to `.p8` key file)
+
+### Option B: Apple ID + app-specific password
+
+Set:
+- `APPLE_ID`
+- `APPLE_PASSWORD` (app-specific password)
+- `APPLE_TEAM_ID`
+
+Generate app-specific passwords at [account.apple.com](https://account.apple.com/).
+
+## 4) Local Build Env File
+
+Create a local file (never commit):
+
+```bash
+cat > .env.build <<'EOF'
+# Signing
+export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
+
+# Notarization (choose one approach)
+# Option A: API key
+# export APPLE_API_ISSUER="00000000-0000-0000-0000-000000000000"
+# export APPLE_API_KEY="ABC123XYZ9"
+# export APPLE_API_KEY_PATH="$HOME/.private_keys/AuthKey_ABC123XYZ9.p8"
+
+# Option B: Apple ID + app-specific password
+# export APPLE_ID="you@example.com"
+# export APPLE_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+# export APPLE_TEAM_ID="TEAMID1234"
+EOF
+```
+
+Add to `.gitignore` if needed:
+
+```bash
+echo ".env.build" >> .gitignore
+```
+
+## 5) Build Commands (This Repo)
+
+Load env vars:
+
+```bash
+source .env.build
+```
+
+Universal build (recommended for distribution):
+
+```bash
+bun run tauri build --target universal-apple-darwin
+```
+
+Single-arch builds:
+
+```bash
+bun run tauri build --target x86_64-apple-darwin
+bun run tauri build --target aarch64-apple-darwin
+```
+
+Outputs are under:
+- `src-tauri/target/universal-apple-darwin/release/bundle/macos/`
+- `src-tauri/target/universal-apple-darwin/release/bundle/dmg/`
+
+## 6) Verify Signature + Gatekeeper + Stapling
+
+```bash
+codesign --verify --deep --strict --verbose=2 "src-tauri/target/universal-apple-darwin/release/bundle/macos/Bablusheed.app"
+spctl --assess --type execute --verbose=4 "src-tauri/target/universal-apple-darwin/release/bundle/macos/Bablusheed.app"
+xcrun stapler validate "src-tauri/target/universal-apple-darwin/release/bundle/macos/Bablusheed.app"
+```
+
+## 7) CI Notes (GitHub Actions)
+
+This repo already uses `tauri-apps/tauri-action` in `.github/workflows/release.yml`.
+
+For CI signing/notarization, set secrets and expose env vars in the `Build and upload Tauri bundles` step (same names as above). If using a `.p12` certificate in CI, Tauri also supports:
+- `APPLE_CERTIFICATE` (Base64-encoded `.p12`)
+- `APPLE_CERTIFICATE_PASSWORD`
+
+## 8) Troubleshooting
+
+No signing identity:
+
+```bash
+security find-identity -v -p codesigning
+```
+
+Notarization log lookup (Apple ID mode):
+
+```bash
+xcrun notarytool log <submission-id> --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_PASSWORD"
+```
+
+Notarization log lookup (API key mode):
+
+```bash
+xcrun notarytool log <submission-id> --key "$APPLE_API_KEY_PATH" --key-id "$APPLE_API_KEY" --issuer "$APPLE_API_ISSUER"
+```
+
+## References
+
+- [Tauri v2 Prerequisites](https://v2.tauri.app/start/prerequisites/)
+- [Tauri v2 macOS Signing + Notarization](https://v2.tauri.app/distribute/sign/macos/)
+- [Tauri CLI build targets (including universal-apple-darwin)](https://docs.rs/crate/tauri-cli/latest/source/README.md)
+- [Apple support: app-specific passwords](https://support.apple.com/en-ca/102654)

--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
-  "name": "bablusheed",
-  "private": true,
-  "version": "1.0.1",
-  "description": "Tauri desktop app that packs project files into token-aware, LLM-friendly bundles.",
   "author": {
     "name": "Ragaeeb Haq",
     "url": "https://github.com/ragaeeb"
+  },
+  "bugs": {
+    "url": "https://github.com/ragaeeb/bablusheed/issues"
   },
   "contributors": [
     {
@@ -13,46 +12,6 @@
       "url": "https://github.com/ragaeeb"
     }
   ],
-  "keywords": [
-    "tauri",
-    "react",
-    "llm",
-    "tokenizer",
-    "prompt-engineering",
-    "code-packer"
-  ],
-  "license": "MIT",
-  "homepage": "https://github.com/ragaeeb/bablusheed",
-  "bugs": {
-    "url": "https://github.com/ragaeeb/bablusheed/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/ragaeeb/bablusheed.git"
-  },
-  "engines": {
-    "bun": ">=1.3.10",
-    "node": ">=25.0.0"
-  },
-  "packageManager": "bun@1.3.10",
-  "type": "module",
-  "scripts": {
-    "ci": "bun test && bun run vite:build && cargo check --manifest-path src-tauri/Cargo.toml",
-    "dev": "tauri dev",
-    "build": "tauri build",
-    "vite:dev": "vite",
-    "vite:build": "tsc && vite build",
-    "test": "bun test",
-    "preview": "vite preview",
-    "tauri": "tauri",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint --write .",
-    "format": "biome format .",
-    "format:fix": "biome format --write .",
-    "sync:icons": "bun scripts/sync-icons.ts",
-    "sync:version": "node scripts/sync-version.mjs",
-    "release": "semantic-release"
-  },
   "dependencies": {
     "@base-ui/react": "^1.2.0",
     "@tanstack/react-virtual": "^3.13.19",
@@ -65,14 +24,15 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "js-tiktoken": "^1.0.21",
-    "lucide-react": "^0.575.0",
+    "lucide-react": "^0.576.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "tailwind-merge": "^3.5.0"
   },
+  "description": "Tauri desktop app that packs project files into token-aware, LLM-friendly bundles.",
   "devDependencies": {
+    "@biomejs/biome": "^2.4.5",
     "@commitlint/config-conventional": "^20.4.2",
-    "@biomejs/biome": "^2.4.4",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/exec": "^7.1.0",
@@ -90,5 +50,45 @@
     "tailwindcss": "^4.2.1",
     "typescript": "~5.9.3",
     "vite": "^7.3.1"
-  }
+  },
+  "engines": {
+    "bun": ">=1.3.10",
+    "node": ">=25.0.0"
+  },
+  "homepage": "https://github.com/ragaeeb/bablusheed",
+  "keywords": [
+    "tauri",
+    "react",
+    "llm",
+    "tokenizer",
+    "prompt-engineering",
+    "code-packer"
+  ],
+  "license": "MIT",
+  "name": "bablusheed",
+  "packageManager": "bun@1.3.10",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ragaeeb/bablusheed.git"
+  },
+  "scripts": {
+    "build": "tauri build",
+    "ci": "bun test && bun run vite:build && cargo check --manifest-path src-tauri/Cargo.toml",
+    "dev": "tauri dev",
+    "format": "biome format .",
+    "format:fix": "biome format --write .",
+    "lint": "biome lint .",
+    "lint:fix": "biome lint --write .",
+    "preview": "vite preview",
+    "release": "semantic-release",
+    "sync:icons": "bun scripts/sync-icons.ts",
+    "sync:version": "node scripts/sync-version.mjs",
+    "tauri": "tauri",
+    "test": "bun test",
+    "vite:build": "tsc && vite build",
+    "vite:dev": "vite"
+  },
+  "type": "module",
+  "version": "1.0.1"
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bablusheed"
-version = "0.1.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "glob",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,10 +3,10 @@ name = "bablusheed"
 version = "1.0.1"
 description = "Bablusheed - Pack project files for LLM consumption"
 authors = ["Ragaeeb Haq"]
-homepage = "https://bablusheed.com"
+homepage = "https://github.com/ragaeeb/bablusheed"
 repository = "https://github.com/ragaeeb/bablusheed"
 license = "MIT"
-edition = "2021"
+edition = "2024"
 
 [lib]
 name = "bablusheed_lib"
@@ -43,5 +43,4 @@ codegen-units = 1
 strip = true
 panic = "abort"
 incremental = false
-
 

--- a/src-tauri/src/commands/ast.rs
+++ b/src-tauri/src/commands/ast.rs
@@ -4,7 +4,8 @@ use tree_sitter::{Node, Parser};
 
 fn get_language(extension: &str) -> Option<tree_sitter::Language> {
     match extension {
-        "ts" | "tsx" => Some(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),
+        "ts" => Some(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),
+        "tsx" => Some(tree_sitter_typescript::LANGUAGE_TSX.into()),
         "js" | "jsx" => Some(tree_sitter_javascript::LANGUAGE.into()),
         "py" => Some(tree_sitter_python::LANGUAGE.into()),
         "rs" => Some(tree_sitter_rust::LANGUAGE.into()),
@@ -108,7 +109,10 @@ fn extract_symbols_from_node(
 
 /// Find all identifier references in a node (for call graph building)
 fn collect_references(node: Node, source: &[u8], refs: &mut HashSet<String>) {
-    if node.kind() == "identifier" || node.kind() == "type_identifier" {
+    if node.kind() == "identifier"
+        || node.kind() == "type_identifier"
+        || node.kind() == "jsx_identifier"
+    {
         let name = node_text(node, source);
         if !name.is_empty() && name.chars().next().map(|c| c.is_alphabetic() || c == '_').unwrap_or(false) {
             refs.insert(name.to_string());
@@ -206,6 +210,7 @@ pub async fn analyze_reachability(
     let mut symbol_map: HashMap<String, String> = HashMap::new(); // symbol -> file_path
     let mut file_symbols: HashMap<String, Vec<String>> = HashMap::new(); // file_path -> symbols
     let mut file_refs: HashMap<String, HashSet<String>> = HashMap::new(); // symbol -> refs
+    let mut file_level_refs: HashMap<String, HashSet<String>> = HashMap::new(); // file_path -> refs
 
     // Parse all files and extract symbols + refs
     for file in &files {
@@ -228,6 +233,9 @@ pub async fn analyze_reachability(
 
         let symbols = extract_symbols(source, &tree);
         let refs_by_symbol = collect_symbol_references(source, &tree);
+        let mut refs_for_file = HashSet::new();
+        collect_references(tree.root_node(), source, &mut refs_for_file);
+        file_level_refs.insert(file.path.clone(), refs_for_file);
 
         for sym in &symbols {
             symbol_map.insert(sym.clone(), file.path.clone());
@@ -250,6 +258,13 @@ pub async fn analyze_reachability(
     for sym in &entry_symbols {
         reachable.insert(sym.clone());
         queue.push_back(sym.clone());
+    }
+    if let Some(entry_refs) = file_level_refs.get(&entry_point) {
+        for sym in entry_refs {
+            if symbol_map.contains_key(sym) && reachable.insert(sym.clone()) {
+                queue.push_back(sym.clone());
+            }
+        }
     }
 
     while let Some(sym) = queue.pop_front() {
@@ -422,5 +437,62 @@ mod tests {
         let refs = parse_and_collect_refs(source, "py");
         let main_refs = refs.get("main").expect("main should have refs");
         assert!(main_refs.contains("helper"));
+    }
+
+    #[tokio::test]
+    async fn analyze_reachability_seeds_from_entry_refs_and_keeps_default_export_graph() {
+        let files = vec![
+            FileContent {
+                path: "/project/src/main.tsx".into(),
+                content: "import App from './App';\ncreateRoot(document.getElementById('root')!).render(<App />);\n".into(),
+                token_count: None,
+            },
+            FileContent {
+                path: "/project/src/App.tsx".into(),
+                content: "import LimitIndicator from './components/LimitIndicator';\nconst App = () => <LimitIndicator percent={50} />;\nexport default App;\n".into(),
+                token_count: None,
+            },
+            FileContent {
+                path: "/project/src/components/LimitIndicator.tsx".into(),
+                content: "const getColorClass = (percent: number): string => {\n  if (percent >= 85) return 'bg-red-500';\n  if (percent >= 60) return 'bg-amber-400';\n  return 'bg-emerald-400';\n};\nconst LimitIndicator = ({ percent }: { percent: number }) => {\n  const clampedPercent = Math.max(0, Math.min(percent, 100));\n  return <div className={getColorClass(clampedPercent)} />;\n};\nexport default LimitIndicator;\n".into(),
+                token_count: None,
+            },
+        ];
+
+        let result = analyze_reachability("/project/src/main.tsx".into(), files)
+            .await
+            .expect("reachability should succeed");
+
+        let app_reachable = result
+            .reachable_symbols
+            .get("/project/src/App.tsx")
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            app_reachable.contains(&"App".to_string()),
+            "App should be reachable from entry refs"
+        );
+
+        let indicator_reachable = result
+            .reachable_symbols
+            .get("/project/src/components/LimitIndicator.tsx")
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            indicator_reachable.contains(&"LimitIndicator".to_string()),
+            "default-exported component should be reachable"
+        );
+        assert!(
+            indicator_reachable.contains(&"getColorClass".to_string()),
+            "helper used by reachable component should be reachable"
+        );
+
+        let indicator_unreachable = result
+            .unreachable_symbols
+            .get("/project/src/components/LimitIndicator.tsx")
+            .cloned()
+            .unwrap_or_default();
+        assert!(!indicator_unreachable.contains(&"LimitIndicator".to_string()));
+        assert!(!indicator_unreachable.contains(&"getColorClass".to_string()));
     }
 }

--- a/src-tauri/src/commands/ast.rs
+++ b/src-tauri/src/commands/ast.rs
@@ -114,7 +114,11 @@ fn collect_references(node: Node, source: &[u8], refs: &mut HashSet<String>) {
         || node.kind() == "jsx_identifier"
     {
         let name = node_text(node, source);
-        if !name.is_empty() && name.chars().next().map(|c| c.is_alphabetic() || c == '_').unwrap_or(false) {
+        let is_jsx = node.kind() == "jsx_identifier";
+        let first = name.chars().next();
+        let is_valid_ident = first.map(|c| c.is_alphabetic() || c == '_').unwrap_or(false);
+        let is_component_like_jsx = first.map(|c| c.is_uppercase()).unwrap_or(false);
+        if !name.is_empty() && is_valid_ident && (!is_jsx || is_component_like_jsx) {
             refs.insert(name.to_string());
         }
     }
@@ -202,6 +206,196 @@ fn collect_symbol_references_from_node(
     }
 }
 
+fn parse_import_clause_bindings(clause_text: &str) -> Vec<(String, String)> {
+    let mut bindings = Vec::new();
+    let text = clause_text.trim();
+    if text.is_empty() {
+        return bindings;
+    }
+
+    let mut parts = text.splitn(2, ',');
+    let first = parts.next().unwrap_or("").trim();
+    let second = parts.next().map(str::trim);
+
+    if !first.is_empty() && !first.starts_with('{') && !first.starts_with('*') {
+        bindings.push((first.to_string(), "default".to_string()));
+    }
+
+    let named_segment = if first.starts_with('{') || first.starts_with('*') {
+        Some(first)
+    } else {
+        second
+    };
+
+    if let Some(segment) = named_segment {
+        if segment.starts_with('*') {
+            if let Some((_, local)) = segment.split_once(" as ") {
+                let local_trimmed = local.trim();
+                if !local_trimmed.is_empty() {
+                    bindings.push((local_trimmed.to_string(), "*".to_string()));
+                }
+            }
+        } else if segment.starts_with('{') && segment.ends_with('}') {
+            let inner = &segment[1..segment.len() - 1];
+            for raw_spec in inner.split(',') {
+                let mut spec = raw_spec.trim();
+                if spec.is_empty() {
+                    continue;
+                }
+                if let Some(stripped) = spec.strip_prefix("type ") {
+                    spec = stripped.trim();
+                }
+                if let Some((imported, local)) = spec.split_once(" as ") {
+                    let imported_trimmed = imported.trim();
+                    let local_trimmed = local.trim();
+                    if !imported_trimmed.is_empty() && !local_trimmed.is_empty() {
+                        bindings.push((local_trimmed.to_string(), imported_trimmed.to_string()));
+                    }
+                } else {
+                    bindings.push((spec.to_string(), spec.to_string()));
+                }
+            }
+        }
+    }
+
+    bindings
+}
+
+fn extract_import_aliases(source: &[u8], tree: &tree_sitter::Tree) -> HashMap<String, (String, String)> {
+    let mut aliases = HashMap::new();
+    let root = tree.root_node();
+    let mut cursor = root.walk();
+    for child in root.children(&mut cursor) {
+        if child.kind() != "import_statement" {
+            continue;
+        }
+
+        let mut source_path: Option<String> = None;
+        let mut clause_text: Option<String> = None;
+        let mut import_cursor = child.walk();
+        for import_child in child.children(&mut import_cursor) {
+            if import_child.kind() == "import_clause" {
+                clause_text = Some(node_text(import_child, source).to_string());
+            } else if import_child.kind() == "identifier" && clause_text.is_none() {
+                // Fallback for grammars that expose default imports directly.
+                clause_text = Some(node_text(import_child, source).to_string());
+            } else if import_child.kind() == "string" {
+                let raw = node_text(import_child, source).trim();
+                if (raw.starts_with('"') && raw.ends_with('"'))
+                    || (raw.starts_with('\'') && raw.ends_with('\''))
+                {
+                    source_path = Some(raw[1..raw.len() - 1].to_string());
+                } else {
+                    source_path = Some(raw.to_string());
+                }
+            }
+        }
+
+        let Some(specifier) = source_path else {
+            continue;
+        };
+        let Some(clause) = clause_text else {
+            continue;
+        };
+        for (local_name, imported_name) in parse_import_clause_bindings(&clause) {
+            aliases.insert(local_name, (imported_name, specifier.clone()));
+        }
+    }
+    aliases
+}
+
+fn normalize_path(path: &std::path::Path) -> String {
+    use std::path::Component;
+
+    let mut prefix = String::new();
+    let mut has_root = false;
+    let mut parts: Vec<String> = Vec::new();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(p) => {
+                prefix = p.as_os_str().to_string_lossy().to_string();
+            }
+            Component::RootDir => {
+                has_root = true;
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let _ = parts.pop();
+            }
+            Component::Normal(segment) => {
+                parts.push(segment.to_string_lossy().to_string());
+            }
+        }
+    }
+
+    let mut normalized = String::new();
+    if !prefix.is_empty() {
+        normalized.push_str(&prefix);
+        if has_root {
+            normalized.push('/');
+        }
+    } else if has_root {
+        normalized.push('/');
+    }
+    normalized.push_str(&parts.join("/"));
+    normalized
+}
+
+fn resolve_import_target_file(
+    current_file: &str,
+    import_specifier: &str,
+    known_files: &HashSet<String>,
+) -> Option<String> {
+    if !import_specifier.starts_with('.') {
+        return None;
+    }
+
+    let current_path = std::path::Path::new(current_file);
+    let base_dir = current_path.parent()?;
+    let joined = base_dir.join(import_specifier);
+    let joined_string = normalize_path(&joined);
+
+    let mut candidates = vec![joined_string.clone()];
+    for ext in ["ts", "tsx", "js", "jsx"] {
+        candidates.push(format!("{joined_string}.{ext}"));
+        candidates.push(format!("{joined_string}/index.{ext}"));
+    }
+
+    candidates
+        .into_iter()
+        .find(|candidate| known_files.contains(candidate))
+}
+
+fn extract_default_export_symbol(source: &str) -> Option<String> {
+    for line in source.lines() {
+        let trimmed = line.trim_start();
+        let Some(after) = trimmed.strip_prefix("export default ") else {
+            continue;
+        };
+        let without_comment = after.split("//").next().unwrap_or("").trim();
+        let expression = without_comment.trim_end_matches(';').trim();
+        if expression.is_empty() {
+            continue;
+        }
+        if expression.starts_with("function ") || expression.starts_with("class ") {
+            continue;
+        }
+        let token = expression
+            .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '$'))
+            .next()
+            .unwrap_or("");
+        if token.is_empty() {
+            continue;
+        }
+        let first = token.chars().next();
+        if first.map(|c| c.is_alphabetic() || c == '_' || c == '$').unwrap_or(false) {
+            return Some(token.to_string());
+        }
+    }
+    None
+}
+
 #[tauri::command]
 pub async fn analyze_reachability(
     entry_point: String,
@@ -211,6 +405,8 @@ pub async fn analyze_reachability(
     let mut file_symbols: HashMap<String, Vec<String>> = HashMap::new(); // file_path -> symbols
     let mut file_refs: HashMap<String, HashSet<String>> = HashMap::new(); // symbol -> refs
     let mut file_level_refs: HashMap<String, HashSet<String>> = HashMap::new(); // file_path -> refs
+    let mut import_aliases_by_file: HashMap<String, HashMap<String, (String, String)>> = HashMap::new();
+    let mut default_export_symbol_by_file: HashMap<String, String> = HashMap::new();
 
     // Parse all files and extract symbols + refs
     for file in &files {
@@ -233,6 +429,15 @@ pub async fn analyze_reachability(
 
         let symbols = extract_symbols(source, &tree);
         let refs_by_symbol = collect_symbol_references(source, &tree);
+        let import_aliases = extract_import_aliases(source, &tree);
+        if !import_aliases.is_empty() {
+            import_aliases_by_file.insert(file.path.clone(), import_aliases);
+        }
+
+        if let Some(default_export) = extract_default_export_symbol(&file.content) {
+            default_export_symbol_by_file.insert(file.path.clone(), default_export);
+        }
+
         let mut refs_for_file = HashSet::new();
         collect_references(tree.root_node(), source, &mut refs_for_file);
         file_level_refs.insert(file.path.clone(), refs_for_file);
@@ -254,15 +459,46 @@ pub async fn analyze_reachability(
 
     let mut reachable: HashSet<String> = HashSet::new();
     let mut queue: VecDeque<String> = VecDeque::new();
+    let known_files: HashSet<String> = file_symbols.keys().cloned().collect();
 
     for sym in &entry_symbols {
         reachable.insert(sym.clone());
         queue.push_back(sym.clone());
     }
     if let Some(entry_refs) = file_level_refs.get(&entry_point) {
+        let import_aliases = import_aliases_by_file.get(&entry_point);
         for sym in entry_refs {
             if symbol_map.contains_key(sym) && reachable.insert(sym.clone()) {
                 queue.push_back(sym.clone());
+                continue;
+            }
+
+            let Some((imported_name, import_specifier)) =
+                import_aliases.and_then(|m| m.get(sym))
+            else {
+                continue;
+            };
+            let Some(target_file) =
+                resolve_import_target_file(&entry_point, import_specifier, &known_files)
+            else {
+                continue;
+            };
+
+            let mapped_symbol = if imported_name == "default" {
+                default_export_symbol_by_file.get(&target_file).cloned()
+            } else {
+                Some(imported_name.clone())
+            };
+
+            if let Some(candidate) = mapped_symbol {
+                if symbol_map
+                    .get(&candidate)
+                    .map(|owner| owner == &target_file)
+                    .unwrap_or(false)
+                    && reachable.insert(candidate.clone())
+                {
+                    queue.push_back(candidate);
+                }
             }
         }
     }
@@ -444,7 +680,7 @@ mod tests {
         let files = vec![
             FileContent {
                 path: "/project/src/main.tsx".into(),
-                content: "import App from './App';\ncreateRoot(document.getElementById('root')!).render(<App />);\n".into(),
+                content: "import Root from './App';\ncreateRoot(document.getElementById('root')!).render(<Root />);\n".into(),
                 token_count: None,
             },
             FileContent {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,8 +31,7 @@ fn configure_macos_menu<R: tauri::Runtime>(app: &tauri::App<R>) -> tauri::Result
         ..Default::default()
     };
 
-    let app_name = app.package_info().name.clone();
-    let app_submenu = SubmenuBuilder::new(app, app_name)
+    let app_submenu = SubmenuBuilder::new(app, "Bablusheed")
         .about(Some(about_metadata))
         .separator()
         .services()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Bablusheed",
   "version": "1.0.1",
-  "identifier": "com.bablusheed.app",
+  "identifier": "com.muslimcode.bablusheed",
   "build": {
     "beforeDevCommand": "bun run vite:dev",
     "devUrl": "http://localhost:1420",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,18 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { dirname } from "@tauri-apps/api/path";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { load } from "@tauri-apps/plugin-store";
-import {
-  Bug,
-  BugOff,
-  Download,
-  FolderOpen,
-  Loader2,
-  Moon,
-  Package2,
-  Sun,
-  Trash2,
-  X,
-} from "lucide-react";
+import { Download, FolderOpen, Loader2, Moon, Package2, Sun, Trash2, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { EmptyState } from "@/components/EmptyState";
 import { FilePreview } from "@/components/FilePreview";
@@ -58,8 +47,12 @@ const DEFAULT_PACK_OPTIONS: PackOptionsType = {
 function countNodes<T extends { isDir: boolean; children?: T[] }>(nodes: T[]): number {
   let count = 0;
   for (const n of nodes) {
-    if (!n.isDir) count++;
-    if (n.children) count += countNodes(n.children);
+    if (!n.isDir) {
+      count++;
+    }
+    if (n.children) {
+      count += countNodes(n.children);
+    }
   }
   return count;
 }
@@ -133,6 +126,23 @@ type DebugLiveMetrics = {
   workerResultCount: number;
 };
 
+type LogLevel = "off" | "error" | "info" | "debug";
+
+const LOG_LEVEL_WEIGHT: Record<LogLevel, number> = {
+  debug: 3,
+  error: 1,
+  info: 2,
+  off: 0,
+};
+
+function isLogLevel(value: unknown): value is LogLevel {
+  return value === "off" || value === "error" || value === "info" || value === "debug";
+}
+
+function shouldCaptureLog(level: LogLevel, incoming: "error" | "info" | "debug"): boolean {
+  return LOG_LEVEL_WEIGHT[level] >= LOG_LEVEL_WEIGHT[incoming];
+}
+
 export default function App() {
   const [theme, setTheme] = useState<"dark" | "light">("light");
   const [projectPath, setProjectPath] = useState<string | null>(null);
@@ -149,7 +159,7 @@ export default function App() {
   // 3l: Last project path for reopen
   const [lastProjectPath, setLastProjectPath] = useState<string | null>(null);
   const [lastProjectName, setLastProjectName] = useState<string | null>(null);
-  const [debugLogging, setDebugLogging] = useState(false);
+  const [logLevel, setLogLevel] = useState<LogLevel>("error");
   const [debugLogs, setDebugLogs] = useState<string[]>([]);
   const [hasManualNumPacksOverride, setHasManualNumPacksOverride] = useState(false);
   const [lastPackedFingerprint, setLastPackedFingerprint] = useState<string | null>(null);
@@ -165,7 +175,7 @@ export default function App() {
 
   const storeRef = useRef<Awaited<ReturnType<typeof load>> | null>(null);
   const loadProjectRef = useRef<(folderPath: string) => Promise<void>>(async () => {});
-  const debugLoggingRef = useRef(false);
+  const logLevelRef = useRef<LogLevel>("error");
   const lastRequestedPackFingerprintRef = useRef<string | null>(null);
   const currentPackFingerprintRef = useRef<string>("");
   const renderSamplesRef = useRef<Record<string, number[]>>({
@@ -208,14 +218,34 @@ export default function App() {
   } = useFileTree();
 
   const llmProfile = getProfile(selectedLlmId);
-  const appendDebugLog = useCallback((line: string) => {
+  const debugLogging = logLevel === "debug";
+  const appendLog = useCallback((level: "error" | "info" | "debug", message: string) => {
+    if (!shouldCaptureLog(logLevelRef.current, level)) {
+      return;
+    }
+    const line = `[${new Date().toISOString()}] [${level}] ${message}`;
     setDebugLogs((prev) => {
       const next = [...prev, line];
       return next.length > 5000 ? next.slice(next.length - 5000) : next;
     });
   }, []);
+  const appendDebugLog = useCallback((line: string) => {
+    if (!shouldCaptureLog(logLevelRef.current, "debug")) {
+      return;
+    }
+    const match = line.match(/^\[([^\]]+)\]\s*(.*)$/);
+    const normalized = match
+      ? `[${match[1]}] [debug] ${match[2]}`
+      : `[${new Date().toISOString()}] [debug] ${line}`;
+    setDebugLogs((prev) => {
+      const next = [...prev, normalized];
+      return next.length > 5000 ? next.slice(next.length - 5000) : next;
+    });
+  }, []);
   const appendRenderSample = (component: string, timestampMs: number) => {
-    if (!debugLogging) return;
+    if (!debugLogging) {
+      return;
+    }
     const bucket = renderSamplesRef.current[component] ?? [];
     bucket.push(timestampMs);
     renderSamplesRef.current[component] = bucket;
@@ -223,7 +253,9 @@ export default function App() {
   const incrementDebugMetric = (
     name: "astRecompute" | "astCacheHit" | "workerQueued" | "workerResult",
   ) => {
-    if (!debugLogging) return;
+    if (!debugLogging) {
+      return;
+    }
     debugMetricCountsRef.current[name] += 1;
   };
 
@@ -254,11 +286,12 @@ export default function App() {
     debugLogging,
     appendDebugLog,
     incrementDebugMetric,
+    appendLog,
   );
 
   useEffect(() => {
-    debugLoggingRef.current = debugLogging;
-  }, [debugLogging]);
+    logLevelRef.current = logLevel;
+  }, [logLevel]);
 
   useEffect(() => {
     if (!debugLogging) {
@@ -311,6 +344,7 @@ export default function App() {
     selectedLlmId,
     llmProfile.contextWindowTokens,
     tokenMap,
+    appendLog,
   );
 
   const advisoryMaxTokensPerFile = resolveAdvisoryMaxTokensPerFile(
@@ -342,7 +376,9 @@ export default function App() {
   const relativeTokenMap = (() => {
     const map = new Map<string, number>();
     for (const file of selectedFiles) {
-      if (file.isDir) continue;
+      if (file.isDir) {
+        continue;
+      }
       const tokens = tokenMap.get(file.path);
       if (tokens !== undefined) {
         map.set(file.relativePath, tokens);
@@ -354,7 +390,11 @@ export default function App() {
   const selectedFileCount = selectedAbsolutePaths.length;
   const maxSensiblePacks = Math.min(llmProfile.maxFileAttachments, Math.max(selectedFileCount, 1));
   const defaultNumPacks = Math.min(maxSensiblePacks, Math.max(1, Math.min(selectedFileCount, 5)));
-  const currentPackFingerprint = buildPackFingerprint(selectedAbsolutePaths, selectedLlmId, packOptions);
+  const currentPackFingerprint = buildPackFingerprint(
+    selectedAbsolutePaths,
+    selectedLlmId,
+    packOptions,
+  );
   const isPackOutdated =
     packResult !== null &&
     lastPackedFingerprint !== null &&
@@ -365,7 +405,9 @@ export default function App() {
   }, [currentPackFingerprint]);
 
   useEffect(() => {
-    if (!packResult) return;
+    if (!packResult) {
+      return;
+    }
     setLastPackedFingerprint(
       lastRequestedPackFingerprintRef.current ?? currentPackFingerprintRef.current,
     );
@@ -388,10 +430,21 @@ export default function App() {
         const savedTheme = await store.get<"dark" | "light">("theme");
         const savedLlmId = await store.get<string>("lastLlmProfileId");
         const savedPackOptions = await store.get<PackOptionsType>("packOptions");
+        const savedLogLevel = await store.get<LogLevel>("logLevel");
+        const legacyDebugLogging = await store.get<boolean>("debugLogging");
         const savedLastPath = await store.get<string>("lastProjectPath");
 
-        if (savedTheme) setTheme(savedTheme);
-        if (savedLlmId) setSelectedLlmId(savedLlmId);
+        if (savedTheme) {
+          setTheme(savedTheme);
+        }
+        if (savedLlmId) {
+          setSelectedLlmId(savedLlmId);
+        }
+        if (isLogLevel(savedLogLevel)) {
+          setLogLevel(savedLogLevel);
+        } else if (legacyDebugLogging) {
+          setLogLevel("debug");
+        }
         if (savedPackOptions) {
           const merged = { ...DEFAULT_PACK_OPTIONS, ...savedPackOptions };
           if (merged.outputFormat !== "markdown" && merged.outputFormat !== "plaintext") {
@@ -424,18 +477,21 @@ export default function App() {
   // 3k: Save settings with 1500ms debounce; don't save projectPath here
   useEffect(() => {
     const timer = setTimeout(async () => {
-      if (!storeRef.current) return;
+      if (!storeRef.current) {
+        return;
+      }
       try {
         await storeRef.current.set("theme", theme);
         await storeRef.current.set("lastLlmProfileId", selectedLlmId);
         await storeRef.current.set("packOptions", packOptions);
+        await storeRef.current.set("logLevel", logLevel);
         await storeRef.current.save();
       } catch (err) {
         console.warn("Failed to save settings:", err);
       }
     }, 1500);
     return () => clearTimeout(timer);
-  }, [theme, selectedLlmId, packOptions]);
+  }, [theme, selectedLlmId, packOptions, logLevel]);
 
   const readProjectFile = useCallback(
     async (path: string): Promise<string> => invoke<string>("read_file_content", { path }),
@@ -447,52 +503,35 @@ export default function App() {
   // is not a dependency (avoids recreating the callback on every Map change).
   const loadFileContent = useCallback(
     async (path: string): Promise<void> => {
-      if (debugLoggingRef.current) {
-        setDebugLogs((prev) => {
-          const next = [...prev, `[${new Date().toISOString()}] preview-read start path=${path}`];
-          return next.length > 5000 ? next.slice(next.length - 5000) : next;
-        });
-      }
+      appendLog("debug", `preview-read start path=${path}`);
       try {
         const content = await readProjectFile(path);
         setFileContents((prev) => {
-          if (prev.has(path)) return prev;
+          if (prev.has(path)) {
+            return prev;
+          }
           const next = new Map(prev);
           next.set(path, content);
           return next;
         });
-        if (debugLoggingRef.current) {
-          setDebugLogs((prev) => {
-            const next = [
-              ...prev,
-              `[${new Date().toISOString()}] preview-read success path=${path} chars=${content.length}`,
-            ];
-            return next.length > 5000 ? next.slice(next.length - 5000) : next;
-          });
-        }
-      } catch {
-        setFileContents((prev) => {
-          if (prev.has(path)) return prev;
-          const next = new Map(prev);
-          next.set(path, "");
-          return next;
-        });
-        if (debugLoggingRef.current) {
-          setDebugLogs((prev) => {
-            const next = [...prev, `[${new Date().toISOString()}] preview-read failed path=${path}`];
-            return next.length > 5000 ? next.slice(next.length - 5000) : next;
-          });
-        }
+        appendLog("debug", `preview-read success path=${path} chars=${content.length}`);
+      } catch (err) {
+        appendLog("error", `preview-read failed path=${path} err=${String(err)}`);
       }
     },
-    [readProjectFile],
+    [appendLog, readProjectFile],
   );
 
   // Load content for selected files whenever selection changes.
   // Filter to only files not yet loaded to avoid redundant reads.
   useEffect(() => {
-    const filesToLoad = selectedAbsolutePaths.filter((path) => !fileContents.has(path));
-    if (filesToLoad.length === 0) return;
+    const filesToLoad = selectedFiles
+      .filter((f) => !f.isDir)
+      .map((f) => f.path)
+      .filter((path) => !fileContents.has(path));
+    if (filesToLoad.length === 0) {
+      return;
+    }
 
     let cancelled = false;
     const loadMissingContents = async () => {
@@ -502,17 +541,23 @@ export default function App() {
           try {
             const content = await readProjectFile(path);
             updates.set(path, content);
-          } catch {
-            updates.set(path, "");
+          } catch (err) {
+            appendLog("error", `selection-preload failed path=${path} err=${String(err)}`);
           }
         }),
       );
-      if (cancelled || updates.size === 0) return;
+      if (cancelled || updates.size === 0) {
+        return;
+      }
       setFileContents((prev) => {
         const toAdd = Array.from(updates.entries()).filter(([k]) => !prev.has(k));
-        if (toAdd.length === 0) return prev;
+        if (toAdd.length === 0) {
+          return prev;
+        }
         const next = new Map(prev);
-        for (const [k, v] of toAdd) next.set(k, v);
+        for (const [k, v] of toAdd) {
+          next.set(k, v);
+        }
         return next;
       });
     };
@@ -521,7 +566,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [fileContents, readProjectFile, selectedAbsolutePaths]);
+  }, [appendLog, fileContents, readProjectFile, selectedFiles]);
 
   // 3i: loadProject reads from refs, stable reference
   const loadProject = async (folderPath: string) => {
@@ -533,6 +578,7 @@ export default function App() {
     const parts = folderPath.replace(/\\/g, "/").split("/");
     const name = parts[parts.length - 1] ?? folderPath;
     setProjectName(name);
+    appendLog("info", `project-load start path=${folderPath}`);
 
     try {
       const customIgnoreList = ignorePatternRef.current
@@ -549,6 +595,7 @@ export default function App() {
       loadTree(nodes);
 
       const totalFileCount = countNodes(nodes);
+      appendLog("info", `project-load tree-ready path=${folderPath} files=${totalFileCount}`);
       if (totalFileCount < 50) {
         const contentMap = new Map<string, string>();
 
@@ -560,8 +607,8 @@ export default function App() {
               try {
                 const content = await readProjectFile(node.path);
                 contentMap.set(node.path, content);
-              } catch {
-                contentMap.set(node.path, "");
+              } catch (err) {
+                appendLog("error", `project-preload failed path=${node.path} err=${String(err)}`);
               }
             }
           });
@@ -580,8 +627,10 @@ export default function App() {
       }
       setLastProjectPath(folderPath);
       setLastProjectName(name);
+      appendLog("info", `project-load success path=${folderPath}`);
     } catch (err) {
       console.error("Failed to load project:", err);
+      appendLog("error", `project-load failed path=${folderPath} err=${String(err)}`);
     } finally {
       setIsLoadingTree(false);
     }
@@ -590,15 +639,20 @@ export default function App() {
   loadProjectRef.current = loadProject;
 
   const handleOpenProject = async () => {
+    appendLog("debug", "project-open-dialog start");
     const selected = await open({ directory: true, multiple: false });
     if (selected && typeof selected === "string") {
+      appendLog("info", `project-open-dialog selected path=${selected}`);
       await loadProject(selected);
+    } else {
+      appendLog("debug", "project-open-dialog cancelled");
     }
   };
 
   // 3l: Reopen last project
   const handleReopenLastProject = async () => {
     if (lastProjectPath) {
+      appendLog("info", `project-reopen path=${lastProjectPath}`);
       await loadProject(lastProjectPath);
     }
   };
@@ -628,6 +682,10 @@ export default function App() {
   }, []);
 
   const handlePack = async () => {
+    appendLog(
+      "info",
+      `pack-trigger selected=${selectedFileCount} packs=${packOptions.numPacks} llm=${selectedLlmId}`,
+    );
     lastRequestedPackFingerprintRef.current = currentPackFingerprint;
     await pack(packOptions);
     setShowOutput(true);
@@ -650,6 +708,7 @@ export default function App() {
   };
 
   const handleCloseProject = () => {
+    appendLog("info", `project-close path=${projectPath ?? "none"}`);
     setProjectPath(null);
     setProjectName("");
     setPreviewPath(null);
@@ -670,17 +729,17 @@ export default function App() {
   };
 
   const handleExportDebugLogs = async () => {
-    if (debugLogs.length === 0) return;
-    appendDebugLog(
-      `[${new Date().toISOString()}] bug-report export start lines=${debugLogs.length}`,
-    );
+    if (debugLogs.length === 0) {
+      return;
+    }
+    appendLog("info", `bug-report export start lines=${debugLogs.length}`);
     try {
       const path = await save({
         defaultPath: `bablusheed_bug_report_${new Date().toISOString().replace(/[:.]/g, "-")}.txt`,
         filters: [{ extensions: ["txt", "log"], name: "Log Files" }],
       });
       if (!path) {
-        appendDebugLog(`[${new Date().toISOString()}] bug-report export cancelled`);
+        appendLog("info", "bug-report export cancelled");
         return;
       }
       const exportDir = await dirname(path);
@@ -691,6 +750,7 @@ export default function App() {
         `Generated: ${new Date().toISOString()}`,
         `Project: ${projectPath ?? "none"}`,
         `Model: ${llmProfile.name}`,
+        `Log level: ${logLevel}`,
         `Selected files: ${selectedFiles.length}`,
         "",
       ].join("\n");
@@ -699,14 +759,10 @@ export default function App() {
         content: `${header}${debugLogs.join("\n")}\n`,
         path,
       });
-      appendDebugLog(
-        `[${new Date().toISOString()}] bug-report export success path=${path} lines=${debugLogs.length}`,
-      );
+      appendLog("info", `bug-report export success path=${path} lines=${debugLogs.length}`);
     } catch (err) {
       console.error("Failed to export debug logs:", err);
-      appendDebugLog(
-        `[${new Date().toISOString()}] bug-report export failed err=${String(err)}`,
-      );
+      appendLog("error", `bug-report export failed err=${String(err)}`);
     }
   };
 
@@ -726,17 +782,16 @@ export default function App() {
     if (!hasManualNumPacksOverride && packOptions.numPacks !== defaultNumPacks) {
       setPackOptions((prev) => ({ ...prev, numPacks: defaultNumPacks }));
     }
-  }, [
-    defaultNumPacks,
-    hasManualNumPacksOverride,
-    maxSensiblePacks,
-    packOptions.numPacks,
-  ]);
+  }, [defaultNumPacks, hasManualNumPacksOverride, maxSensiblePacks, packOptions.numPacks]);
 
   // 2b: Determine current workflow step
   const workflowStep: WorkflowStep = (() => {
-    if (showOutput && packResult) return 3;
-    if (selectedFiles.length > 0) return 2;
+    if (showOutput && packResult) {
+      return 3;
+    }
+    if (selectedFiles.length > 0) {
+      return 2;
+    }
     return 1;
   })();
 
@@ -744,13 +799,19 @@ export default function App() {
 
   // Find the preview file node
   const previewFile = (() => {
-    if (!previewPath) return null;
+    if (!previewPath) {
+      return null;
+    }
     function findNode(nodes: typeof rootNodes): (typeof rootNodes)[0] | null {
       for (const n of nodes) {
-        if (n.path === previewPath) return n;
+        if (n.path === previewPath) {
+          return n;
+        }
         if (n.children) {
           const found = findNode(n.children);
-          if (found) return found;
+          if (found) {
+            return found;
+          }
         }
       }
       return null;
@@ -851,31 +912,32 @@ export default function App() {
               <div className="shrink-0 px-3 py-2 border-b border-border space-y-2 bg-card/50">
                 <div className="flex items-center gap-2">
                   <LLMSelector selectedId={selectedLlmId} onSelect={setSelectedLlmId} />
-                  <button
-                    type="button"
-                    onClick={() => setDebugLogging((v) => !v)}
-                    className={cn(
-                      "h-7 w-7 inline-flex items-center justify-center rounded border transition-colors",
-                      debugLogging
-                        ? "border-primary bg-primary/10 text-primary hover:bg-primary/15"
-                        : "border-border bg-background text-muted-foreground hover:text-foreground hover:bg-muted",
-                    )}
-                    title={debugLogging ? "Disable debug logging" : "Enable debug logging"}
-                    aria-label={debugLogging ? "Disable debug logging" : "Enable debug logging"}
-                  >
-                    {debugLogging ? (
-                      <BugOff className="h-3.5 w-3.5" />
-                    ) : (
-                      <Bug className="h-3.5 w-3.5" />
-                    )}
-                  </button>
+                  <div className="inline-flex items-center gap-1.5 h-7 px-2 rounded border border-border bg-background">
+                    <span className="text-[10px] font-medium text-muted-foreground">Logs</span>
+                    <select
+                      value={logLevel}
+                      onChange={(e) => {
+                        const next = e.target.value;
+                        if (isLogLevel(next)) {
+                          setLogLevel(next);
+                        }
+                      }}
+                      className="h-5 rounded border border-border bg-background px-1 text-[10px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                      aria-label="Log verbosity"
+                    >
+                      <option value="off">Off</option>
+                      <option value="error">Errors</option>
+                      <option value="info">Info</option>
+                      <option value="debug">Debug</option>
+                    </select>
+                  </div>
                   <button
                     type="button"
                     onClick={handleExportDebugLogs}
                     disabled={debugLogs.length === 0}
                     className="h-7 w-7 inline-flex items-center justify-center rounded border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                    title="Export debug logs"
-                    aria-label="Export debug logs"
+                    title="Download bug report"
+                    aria-label="Download bug report"
                   >
                     <Download className="h-3.5 w-3.5" />
                   </button>
@@ -917,20 +979,26 @@ export default function App() {
                   }
                   onDeselectHeaviest={handleDeselectHeaviest}
                 />
-                {debugLogging && (
+                {logLevel !== "off" && (
                   <div className="text-[10px] font-mono text-amber-600 dark:text-amber-400 space-y-0.5">
-                    <div>Debug logging enabled: {debugLogs.length} entries</div>
-                    <div className="text-[9px] text-muted-foreground">
-                      renders/min app:{debugLiveMetrics.appRendersPerMin} tree:
-                      {debugLiveMetrics.fileTreeRendersPerMin} preview:
-                      {debugLiveMetrics.outputPreviewRendersPerMin}
+                    <div>
+                      Logging: {logLevel} · {debugLogs.length} entries
                     </div>
-                    <div className="text-[9px] text-muted-foreground">
-                      ast recompute:{debugLiveMetrics.astRecomputeCount} cache-hit:
-                      {debugLiveMetrics.astCacheHitCount} queued:
-                      {debugLiveMetrics.workerQueuedCount} result:
-                      {debugLiveMetrics.workerResultCount}
-                    </div>
+                    {debugLogging && (
+                      <>
+                        <div className="text-[9px] text-muted-foreground">
+                          renders/min app:{debugLiveMetrics.appRendersPerMin} tree:
+                          {debugLiveMetrics.fileTreeRendersPerMin} preview:
+                          {debugLiveMetrics.outputPreviewRendersPerMin}
+                        </div>
+                        <div className="text-[9px] text-muted-foreground">
+                          ast recompute:{debugLiveMetrics.astRecomputeCount} cache-hit:
+                          {debugLiveMetrics.astCacheHitCount} queued:
+                          {debugLiveMetrics.workerQueuedCount} result:
+                          {debugLiveMetrics.workerResultCount}
+                        </div>
+                      </>
+                    )}
                   </div>
                 )}
 
@@ -1081,6 +1149,7 @@ export default function App() {
                   tokenMap={relativeTokenMap}
                   debugLogging={debugLogging}
                   onDebugLog={appendDebugLog}
+                  onEventLog={appendLog}
                   onRenderSample={appendRenderSample}
                   onClose={() => {
                     setShowOutput(false);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,29 @@ function countNodes<T extends { isDir: boolean; children?: T[] }>(nodes: T[]): n
   return count;
 }
 
+function buildPackFingerprint(
+  selectedPaths: string[],
+  llmId: string,
+  options: PackOptionsType,
+): string {
+  return JSON.stringify({
+    llmId,
+    options: {
+      astDeadCode: options.astDeadCode,
+      entryPoint: options.entryPoint,
+      maxTokensPerPackFile: options.maxTokensPerPackFile,
+      minifyMarkdown: options.minifyMarkdown,
+      numPacks: options.numPacks,
+      outputFormat: options.outputFormat,
+      reduceWhitespace: options.reduceWhitespace,
+      stripComments: options.stripComments,
+      stripMarkdownBlockquotes: options.stripMarkdownBlockquotes,
+      stripMarkdownHeadings: options.stripMarkdownHeadings,
+    },
+    selectedPaths: [...selectedPaths].sort(),
+  });
+}
+
 /** 2b: Workflow step indicator */
 type WorkflowStep = 1 | 2 | 3;
 
@@ -128,6 +151,8 @@ export default function App() {
   const [lastProjectName, setLastProjectName] = useState<string | null>(null);
   const [debugLogging, setDebugLogging] = useState(false);
   const [debugLogs, setDebugLogs] = useState<string[]>([]);
+  const [hasManualNumPacksOverride, setHasManualNumPacksOverride] = useState(false);
+  const [lastPackedFingerprint, setLastPackedFingerprint] = useState<string | null>(null);
   const [debugLiveMetrics, setDebugLiveMetrics] = useState<DebugLiveMetrics>({
     appRendersPerMin: 0,
     astCacheHitCount: 0,
@@ -140,6 +165,9 @@ export default function App() {
 
   const storeRef = useRef<Awaited<ReturnType<typeof load>> | null>(null);
   const loadProjectRef = useRef<(folderPath: string) => Promise<void>>(async () => {});
+  const debugLoggingRef = useRef(false);
+  const lastRequestedPackFingerprintRef = useRef<string | null>(null);
+  const currentPackFingerprintRef = useRef<string>("");
   const renderSamplesRef = useRef<Record<string, number[]>>({
     App: [],
     FileTree: [],
@@ -180,12 +208,12 @@ export default function App() {
   } = useFileTree();
 
   const llmProfile = getProfile(selectedLlmId);
-  const appendDebugLog = (line: string) => {
+  const appendDebugLog = useCallback((line: string) => {
     setDebugLogs((prev) => {
       const next = [...prev, line];
       return next.length > 5000 ? next.slice(next.length - 5000) : next;
     });
-  };
+  }, []);
   const appendRenderSample = (component: string, timestampMs: number) => {
     if (!debugLogging) return;
     const bucket = renderSamplesRef.current[component] ?? [];
@@ -227,6 +255,10 @@ export default function App() {
     appendDebugLog,
     incrementDebugMetric,
   );
+
+  useEffect(() => {
+    debugLoggingRef.current = debugLogging;
+  }, [debugLogging]);
 
   useEffect(() => {
     if (!debugLogging) {
@@ -319,6 +351,25 @@ export default function App() {
     return map;
   })();
   const selectedAbsolutePaths = selectedFiles.filter((f) => !f.isDir).map((f) => f.path);
+  const selectedFileCount = selectedAbsolutePaths.length;
+  const maxSensiblePacks = Math.min(llmProfile.maxFileAttachments, Math.max(selectedFileCount, 1));
+  const defaultNumPacks = Math.min(maxSensiblePacks, Math.max(1, Math.min(selectedFileCount, 5)));
+  const currentPackFingerprint = buildPackFingerprint(selectedAbsolutePaths, selectedLlmId, packOptions);
+  const isPackOutdated =
+    packResult !== null &&
+    lastPackedFingerprint !== null &&
+    lastPackedFingerprint !== currentPackFingerprint;
+
+  useEffect(() => {
+    currentPackFingerprintRef.current = currentPackFingerprint;
+  }, [currentPackFingerprint]);
+
+  useEffect(() => {
+    if (!packResult) return;
+    setLastPackedFingerprint(
+      lastRequestedPackFingerprintRef.current ?? currentPackFingerprintRef.current,
+    );
+  }, [packResult]);
 
   // Update token counts in tree when tokenMap changes
   useEffect(() => {
@@ -394,24 +445,48 @@ export default function App() {
   // 3c: Lazy file content loading — load on demand, cache in fileContents.
   // Uses functional updater to check existence inside the updater so fileContents
   // is not a dependency (avoids recreating the callback on every Map change).
-  const loadFileContent = async (path: string): Promise<void> => {
-    try {
-      const content = await readProjectFile(path);
-      setFileContents((prev) => {
-        if (prev.has(path)) return prev;
-        const next = new Map(prev);
-        next.set(path, content);
-        return next;
-      });
-    } catch {
-      setFileContents((prev) => {
-        if (prev.has(path)) return prev;
-        const next = new Map(prev);
-        next.set(path, "");
-        return next;
-      });
-    }
-  };
+  const loadFileContent = useCallback(
+    async (path: string): Promise<void> => {
+      if (debugLoggingRef.current) {
+        setDebugLogs((prev) => {
+          const next = [...prev, `[${new Date().toISOString()}] preview-read start path=${path}`];
+          return next.length > 5000 ? next.slice(next.length - 5000) : next;
+        });
+      }
+      try {
+        const content = await readProjectFile(path);
+        setFileContents((prev) => {
+          if (prev.has(path)) return prev;
+          const next = new Map(prev);
+          next.set(path, content);
+          return next;
+        });
+        if (debugLoggingRef.current) {
+          setDebugLogs((prev) => {
+            const next = [
+              ...prev,
+              `[${new Date().toISOString()}] preview-read success path=${path} chars=${content.length}`,
+            ];
+            return next.length > 5000 ? next.slice(next.length - 5000) : next;
+          });
+        }
+      } catch {
+        setFileContents((prev) => {
+          if (prev.has(path)) return prev;
+          const next = new Map(prev);
+          next.set(path, "");
+          return next;
+        });
+        if (debugLoggingRef.current) {
+          setDebugLogs((prev) => {
+            const next = [...prev, `[${new Date().toISOString()}] preview-read failed path=${path}`];
+            return next.length > 5000 ? next.slice(next.length - 5000) : next;
+          });
+        }
+      }
+    },
+    [readProjectFile],
+  );
 
   // Load content for selected files whenever selection changes.
   // Filter to only files not yet loaded to avoid redundant reads.
@@ -451,6 +526,9 @@ export default function App() {
   // 3i: loadProject reads from refs, stable reference
   const loadProject = async (folderPath: string) => {
     setIsLoadingTree(true);
+    setHasManualNumPacksOverride(false);
+    setLastPackedFingerprint(null);
+    lastRequestedPackFingerprintRef.current = null;
     setProjectPath(folderPath);
     const parts = folderPath.replace(/\\/g, "/").split("/");
     const name = parts[parts.length - 1] ?? folderPath;
@@ -550,6 +628,7 @@ export default function App() {
   }, []);
 
   const handlePack = async () => {
+    lastRequestedPackFingerprintRef.current = currentPackFingerprint;
     await pack(packOptions);
     setShowOutput(true);
   };
@@ -576,6 +655,9 @@ export default function App() {
     setPreviewPath(null);
     setCenterTab("options");
     setFileContents(new Map());
+    setHasManualNumPacksOverride(false);
+    setLastPackedFingerprint(null);
+    lastRequestedPackFingerprintRef.current = null;
     setShowOutput(false);
     setSearchQuery("");
     setHighlightedPath(null);
@@ -589,12 +671,18 @@ export default function App() {
 
   const handleExportDebugLogs = async () => {
     if (debugLogs.length === 0) return;
+    appendDebugLog(
+      `[${new Date().toISOString()}] bug-report export start lines=${debugLogs.length}`,
+    );
     try {
       const path = await save({
-        defaultPath: `bablusheed_debug_${new Date().toISOString().replace(/[:.]/g, "-")}.log`,
-        filters: [{ extensions: ["log", "txt"], name: "Log Files" }],
+        defaultPath: `bablusheed_bug_report_${new Date().toISOString().replace(/[:.]/g, "-")}.txt`,
+        filters: [{ extensions: ["txt", "log"], name: "Log Files" }],
       });
-      if (!path) return;
+      if (!path) {
+        appendDebugLog(`[${new Date().toISOString()}] bug-report export cancelled`);
+        return;
+      }
       const exportDir = await dirname(path);
       await invoke("authorize_export_directory", { path: exportDir });
 
@@ -611,21 +699,39 @@ export default function App() {
         content: `${header}${debugLogs.join("\n")}\n`,
         path,
       });
+      appendDebugLog(
+        `[${new Date().toISOString()}] bug-report export success path=${path} lines=${debugLogs.length}`,
+      );
     } catch (err) {
       console.error("Failed to export debug logs:", err);
+      appendDebugLog(
+        `[${new Date().toISOString()}] bug-report export failed err=${String(err)}`,
+      );
     }
   };
 
   // 3n: Cap numPacks slider max at selectedFiles.length
-  const maxSensiblePacks = Math.min(
-    llmProfile.maxFileAttachments,
-    Math.max(selectedFiles.length, 1),
-  );
+  useEffect(() => {
+    if (selectedFileCount === 0) {
+      setHasManualNumPacksOverride(false);
+    }
+  }, [selectedFileCount]);
+
   useEffect(() => {
     if (packOptions.numPacks > maxSensiblePacks) {
       setPackOptions((prev) => ({ ...prev, numPacks: maxSensiblePacks }));
+      return;
     }
-  }, [maxSensiblePacks, packOptions.numPacks]);
+
+    if (!hasManualNumPacksOverride && packOptions.numPacks !== defaultNumPacks) {
+      setPackOptions((prev) => ({ ...prev, numPacks: defaultNumPacks }));
+    }
+  }, [
+    defaultNumPacks,
+    hasManualNumPacksOverride,
+    maxSensiblePacks,
+    packOptions.numPacks,
+  ]);
 
   // 2b: Determine current workflow step
   const workflowStep: WorkflowStep = (() => {
@@ -879,6 +985,8 @@ export default function App() {
                     isSelected={previewFile.checkState === "checked"}
                     onToggleSelect={toggleCheck}
                     onLoadContent={loadFileContent}
+                    debugLogging={debugLogging}
+                    onDebugLog={appendDebugLog}
                     onClose={handleClosePreview}
                   />
                 </div>
@@ -888,7 +996,12 @@ export default function App() {
                   <div className="flex-1 overflow-y-auto">
                     <PackOptions
                       options={packOptions}
-                      onChange={setPackOptions}
+                      onChange={(next) => {
+                        if (next.numPacks !== packOptions.numPacks) {
+                          setHasManualNumPacksOverride(true);
+                        }
+                        setPackOptions(next);
+                      }}
                       maxPacks={maxSensiblePacks}
                       selectedFiles={selectedFiles}
                       contextWindowTokens={llmProfile.contextWindowTokens}
@@ -908,6 +1021,11 @@ export default function App() {
 
                   {/* Pack button */}
                   <div className="shrink-0 px-3 py-2 border-t border-border bg-card/50">
+                    {isPackOutdated && (
+                      <p className="text-[11px] text-amber-700 dark:text-amber-400 mb-1.5 font-medium">
+                        Output is out of date. Selection or options changed since last pack.
+                      </p>
+                    )}
                     {packError && (
                       <p className="text-[11px] text-red-500 dark:text-red-400 mb-1.5 font-mono">
                         {packError}
@@ -929,8 +1047,13 @@ export default function App() {
                     <button
                       type="button"
                       onClick={handlePack}
-                      disabled={selectedFiles.length === 0 || isPacking}
-                      className="w-full h-8 inline-flex items-center justify-center gap-2 text-xs font-semibold rounded-md bg-primary text-primary-foreground shadow-sm cursor-pointer transition-all duration-150 hover:bg-primary/90 hover:-translate-y-0.5 hover:shadow-md active:translate-y-0 active:shadow-sm disabled:opacity-40 disabled:cursor-not-allowed"
+                      disabled={selectedFileCount === 0 || isPacking}
+                      className={cn(
+                        "w-full h-8 inline-flex items-center justify-center gap-2 text-xs font-semibold rounded-md text-primary-foreground shadow-sm cursor-pointer transition-all duration-150 hover:-translate-y-0.5 hover:shadow-md active:translate-y-0 active:shadow-sm disabled:opacity-40 disabled:cursor-not-allowed",
+                        isPackOutdated
+                          ? "bg-amber-600 hover:bg-amber-500"
+                          : "bg-primary hover:bg-primary/90",
+                      )}
                     >
                       {isPacking ? (
                         <>
@@ -940,8 +1063,8 @@ export default function App() {
                       ) : (
                         <>
                           <Package2 className="h-3.5 w-3.5" />
-                          Pack{" "}
-                          {selectedFiles.length > 0 ? `${selectedFiles.length} Files` : "Files"}
+                          {isPackOutdated ? "Re-Pack" : "Pack"}{" "}
+                          {selectedFileCount > 0 ? `${selectedFileCount} Files` : "Files"}
                         </>
                       )}
                     </button>
@@ -961,6 +1084,8 @@ export default function App() {
                   onRenderSample={appendRenderSample}
                   onClose={() => {
                     setShowOutput(false);
+                    setLastPackedFingerprint(null);
+                    lastRequestedPackFingerprintRef.current = null;
                     clearResult();
                   }}
                 />

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -10,10 +10,10 @@ interface ErrorBoundaryProps {
 }
 
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  state: ErrorBoundaryState = { hasError: false, error: "" };
+  state: ErrorBoundaryState = { error: "", hasError: false };
 
   static getDerivedStateFromError(err: Error): ErrorBoundaryState {
-    return { hasError: true, error: err.message };
+    return { error: err.message, hasError: true };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo): void {
@@ -32,7 +32,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
             <p className="text-xs text-muted-foreground font-mono break-all">{this.state.error}</p>
             <button
               type="button"
-              onClick={() => this.setState({ hasError: false, error: "" })}
+              onClick={() => this.setState({ error: "", hasError: false })}
               className="inline-flex items-center gap-2 h-8 px-4 text-xs font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
             >
               Retry

--- a/src/components/FilePreview.tsx
+++ b/src/components/FilePreview.tsx
@@ -1,27 +1,27 @@
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { Check, Copy, Eye, EyeOff, Loader2 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { cn, formatTokenCount, minifyMarkdown, reduceWhitespace, stripComments } from "@/lib/utils";
 import type { FileTreeNode, PackOptions } from "@/types";
 
 const colorMap: Record<string, string> = {
+  css: "text-purple-500",
+  go: "text-cyan-600",
+  html: "text-orange-400",
+  js: "text-yellow-500",
+  json: "text-green-500",
+  jsx: "text-cyan-400",
+  lock: "text-slate-400",
+  md: "text-slate-400",
+  py: "text-blue-400",
+  rs: "text-orange-500",
+  sh: "text-emerald-500",
+  svg: "text-pink-400",
+  toml: "text-pink-500",
   ts: "text-blue-500",
   tsx: "text-cyan-500",
-  js: "text-yellow-500",
-  jsx: "text-cyan-400",
-  rs: "text-orange-500",
-  py: "text-blue-400",
-  go: "text-cyan-600",
-  md: "text-slate-400",
-  json: "text-green-500",
-  css: "text-purple-500",
-  html: "text-orange-400",
-  toml: "text-pink-500",
   yaml: "text-green-400",
   yml: "text-green-400",
-  svg: "text-pink-400",
-  sh: "text-emerald-500",
-  lock: "text-slate-400",
 };
 
 interface FilePreviewProps {
@@ -62,10 +62,15 @@ export function FilePreview({
   const [isLoading, setIsLoading] = useState(false);
   const cachedPathsRef = useRef(new Set<string>());
 
-  const logDebug = (message: string) => {
-    if (!debugLogging || !onDebugLog) return;
-    onDebugLog(`[preview] ${message}`);
-  };
+  const logDebug = useCallback(
+    (message: string) => {
+      if (!debugLogging || !onDebugLog) {
+        return;
+      }
+      onDebugLog(`[preview] ${message}`);
+    },
+    [debugLogging, onDebugLog],
+  );
 
   useEffect(() => {
     cachedPathsRef.current = new Set(fileContents.keys());
@@ -76,7 +81,9 @@ export function FilePreview({
   // not on every Map mutation.
   const filePath = file?.path;
   useEffect(() => {
-    if (!filePath) return;
+    if (!filePath) {
+      return;
+    }
     if (cachedPathsRef.current.has(filePath)) {
       setIsLoading(false);
       logDebug(`cache-hit path=${filePath}`);
@@ -105,18 +112,22 @@ export function FilePreview({
     return () => {
       alive = false;
     };
-  }, [filePath, onLoadContent]);
+  }, [filePath, onLoadContent, logDebug]);
 
   // Close on Escape
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        onClose();
+      }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, [onClose]);
 
-  if (!file) return null;
+  if (!file) {
+    return null;
+  }
 
   const rawContent = fileContents.get(file.path) ?? "";
   const tokens = tokenMap.get(file.path) ?? 0;
@@ -135,7 +146,7 @@ export function FilePreview({
     optimizedContent = minifyMarkdown(
       optimizedContent,
       packOptions.stripMarkdownHeadings,
-      packOptions.stripMarkdownBlockquotes
+      packOptions.stripMarkdownBlockquotes,
     );
   }
 
@@ -167,11 +178,13 @@ export function FilePreview({
         {/* Breadcrumb */}
         <div className="flex items-center gap-1 text-[11px] font-mono text-muted-foreground/70 mb-1.5 flex-wrap">
           {parts.map((part, i) => (
-            <span key={`breadcrumb-${i}-${part}`} className="flex items-center gap-1">
+            <span key={`breadcrumb-${i.toString()}-${part}`} className="flex items-center gap-1">
               {i > 0 && <span className="text-muted-foreground/40">/</span>}
               <span
                 className={cn(
-                  i === parts.length - 1 ? `font-semibold ${iconColor}` : "text-muted-foreground/60"
+                  i === parts.length - 1
+                    ? `font-semibold ${iconColor}`
+                    : "text-muted-foreground/60",
                 )}
               >
                 {part}
@@ -200,7 +213,7 @@ export function FilePreview({
                 "inline-flex items-center gap-1 h-6 px-2 text-[11px] font-medium rounded border transition-colors",
                 showOptimized
                   ? "bg-primary/10 border-primary/30 text-primary"
-                  : "bg-background border-border text-muted-foreground hover:text-foreground hover:border-primary/50"
+                  : "bg-background border-border text-muted-foreground hover:text-foreground hover:border-primary/50",
               )}
               title={showOptimized ? "Show raw content" : "Show optimized content"}
             >
@@ -219,7 +232,7 @@ export function FilePreview({
                 ? "bg-emerald-50 border-emerald-200 text-emerald-600 dark:bg-emerald-900/20 dark:border-emerald-700 dark:text-emerald-400"
                 : copyError
                   ? "bg-red-50 border-red-200 text-red-600 dark:bg-red-900/20 dark:border-red-700 dark:text-red-400"
-                  : "bg-background border-border text-muted-foreground hover:text-foreground hover:border-primary/50"
+                  : "bg-background border-border text-muted-foreground hover:text-foreground hover:border-primary/50",
             )}
           >
             {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
@@ -234,7 +247,7 @@ export function FilePreview({
               "inline-flex items-center gap-1 h-6 px-2 text-[11px] font-medium rounded border transition-colors",
               isSelected
                 ? "bg-primary text-primary-foreground border-primary hover:bg-primary/90"
-                : "bg-background border-border text-muted-foreground hover:text-foreground hover:border-primary/50"
+                : "bg-background border-border text-muted-foreground hover:text-foreground hover:border-primary/50",
             )}
           >
             {isSelected ? "Deselect" : "Select"}

--- a/src/components/FilePreview.tsx
+++ b/src/components/FilePreview.tsx
@@ -39,6 +39,8 @@ interface FilePreviewProps {
   isSelected: boolean;
   onToggleSelect: (id: string) => void;
   onLoadContent?: (path: string) => Promise<void>;
+  debugLogging?: boolean;
+  onDebugLog?: (line: string) => void;
   onClose: () => void;
 }
 
@@ -50,14 +52,20 @@ export function FilePreview({
   isSelected,
   onToggleSelect,
   onLoadContent,
+  debugLogging = false,
+  onDebugLog,
   onClose,
 }: FilePreviewProps) {
   const [copied, setCopied] = useState(false);
   const [copyError, setCopyError] = useState(false);
   const [showOptimized, setShowOptimized] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const inFlightLoadsRef = useRef(new Set<string>());
   const cachedPathsRef = useRef(new Set<string>());
+
+  const logDebug = (message: string) => {
+    if (!debugLogging || !onDebugLog) return;
+    onDebugLog(`[preview] ${message}`);
+  };
 
   useEffect(() => {
     cachedPathsRef.current = new Set(fileContents.keys());
@@ -69,25 +77,33 @@ export function FilePreview({
   const filePath = file?.path;
   useEffect(() => {
     if (!filePath) return;
-    if (cachedPathsRef.current.has(filePath)) return;
-    if (!onLoadContent) return;
-    if (inFlightLoadsRef.current.has(filePath)) return;
+    if (cachedPathsRef.current.has(filePath)) {
+      setIsLoading(false);
+      logDebug(`cache-hit path=${filePath}`);
+      return;
+    }
+    if (!onLoadContent) {
+      setIsLoading(false);
+      return;
+    }
 
-    inFlightLoadsRef.current.add(filePath);
-    let cancelled = false;
+    const startedAt = Date.now();
+    let alive = true;
     setIsLoading(true);
+    logDebug(`load-start path=${filePath}`);
     onLoadContent(filePath)
       .catch((err) => {
         console.error("Failed to load preview content:", err);
+        logDebug(`load-error path=${filePath} err=${String(err)}`);
       })
       .finally(() => {
-        inFlightLoadsRef.current.delete(filePath);
-        if (!cancelled) {
+        if (alive) {
           setIsLoading(false);
+          logDebug(`load-done path=${filePath} ms=${Date.now() - startedAt}`);
         }
       });
     return () => {
-      cancelled = true;
+      alive = false;
     };
   }, [filePath, onLoadContent]);
 

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -45,30 +45,30 @@ function FileIcon({
   }
 
   const colorMap: Record<string, string> = {
+    css: "text-purple-500",
+    go: "text-cyan-600",
+    html: "text-orange-400",
+    js: "text-yellow-500",
+    json: "text-green-500",
+    jsx: "text-cyan-400",
+    lock: "text-slate-400",
+    md: "text-slate-400",
+    py: "text-blue-400",
+    rs: "text-orange-500",
+    sh: "text-emerald-500",
+    svg: "text-pink-400",
+    toml: "text-pink-500",
     ts: "text-blue-500",
     tsx: "text-cyan-500",
-    js: "text-yellow-500",
-    jsx: "text-cyan-400",
-    rs: "text-orange-500",
-    py: "text-blue-400",
-    go: "text-cyan-600",
-    md: "text-slate-400",
-    json: "text-green-500",
-    css: "text-purple-500",
-    html: "text-orange-400",
-    toml: "text-pink-500",
     yaml: "text-green-400",
     yml: "text-green-400",
-    svg: "text-pink-400",
-    sh: "text-emerald-500",
-    lock: "text-slate-400",
   };
 
   return (
     <File
       className={cn(
         "h-3.5 w-3.5 shrink-0",
-        colorMap[extension.toLowerCase()] ?? "text-muted-foreground/60"
+        colorMap[extension.toLowerCase()] ?? "text-muted-foreground/60",
       )}
     />
   );
@@ -104,7 +104,7 @@ function TreeRow({
       className={cn(
         "flex items-center gap-0.5 px-1 rounded-sm group cursor-pointer min-h-[22px] text-[12px]",
         isHighlighted ? "bg-primary/10 ring-1 ring-primary/30" : "hover:bg-muted/70",
-        isChecked && !node.isDir && "bg-primary/5"
+        isChecked && !node.isDir && "bg-primary/5",
       )}
       style={{ paddingLeft: `${depth * 10 + 4}px` }}
     >
@@ -135,12 +135,12 @@ function TreeRow({
         }}
         className="flex items-center justify-center h-3.5 w-3.5 shrink-0 rounded-sm border transition-colors"
         style={{
-          borderColor: isChecked || isIndeterminate ? "hsl(var(--primary))" : "hsl(var(--border))",
           backgroundColor: isChecked
             ? "hsl(var(--primary))"
             : isIndeterminate
               ? "hsl(var(--primary) / 0.3)"
               : "transparent",
+          borderColor: isChecked || isIndeterminate ? "hsl(var(--primary))" : "hsl(var(--border))",
         }}
         aria-label={`Select ${node.name}`}
       >
@@ -178,7 +178,7 @@ function TreeRow({
               ? "text-foreground/80 font-medium"
               : isChecked
                 ? "text-foreground"
-                : "text-foreground/70 group-hover:text-foreground/90"
+                : "text-foreground/70 group-hover:text-foreground/90",
           )}
         >
           {node.name}
@@ -245,8 +245,8 @@ export function FileTree({
 
   const rowVirtualizer = useVirtualizer({
     count: flatItems.length,
-    getScrollElement: () => containerRef.current,
     estimateSize: () => 22,
+    getScrollElement: () => containerRef.current,
     overscan: 10,
   });
 
@@ -334,7 +334,7 @@ export function FileTree({
                 "text-[10px] px-1.5 py-0.5 rounded border font-medium transition-colors",
                 filter === "clear"
                   ? "border-border text-muted-foreground hover:text-foreground hover:border-foreground/30"
-                  : "border-primary/30 text-primary/70 hover:text-primary hover:border-primary bg-primary/5 hover:bg-primary/10"
+                  : "border-primary/30 text-primary/70 hover:text-primary hover:border-primary bg-primary/5 hover:bg-primary/10",
               )}
             >
               {label}
@@ -363,12 +363,12 @@ export function FileTree({
                   role="treeitem"
                   aria-selected={item.node.checkState === "checked"}
                   style={{
+                    height: `${virtualItem.size}px`,
+                    left: 0,
                     position: "absolute",
                     top: 0,
-                    left: 0,
-                    width: "100%",
-                    height: `${virtualItem.size}px`,
                     transform: `translateY(${virtualItem.start}px)`,
+                    width: "100%",
                   }}
                   tabIndex={0}
                   onKeyDown={(e) => handleKeyDown(e, item)}

--- a/src/components/OutputPreview.tsx
+++ b/src/components/OutputPreview.tsx
@@ -15,6 +15,7 @@ interface OutputPreviewProps {
   tokenMap?: Map<string, number>;
   debugLogging?: boolean;
   onDebugLog?: (line: string) => void;
+  onEventLog?: (level: "error" | "info" | "debug", message: string) => void;
   onRenderSample?: (component: string, timestampMs: number) => void;
   onClose: () => void;
 }
@@ -76,6 +77,7 @@ export function OutputPreview({
   tokenMap,
   debugLogging = false,
   onDebugLog,
+  onEventLog,
   onRenderSample,
   onClose,
 }: OutputPreviewProps) {
@@ -95,22 +97,30 @@ export function OutputPreview({
 
   const handleExportAll = async () => {
     setExportingAll(true);
+    onEventLog?.("info", `export-all start packs=${packResult.packs.length}`);
     try {
       const folder = await open({
         directory: true,
         multiple: false,
         title: "Select folder for exported packs",
       });
-      if (!folder || typeof folder !== "string") return;
+      if (!folder || typeof folder !== "string") {
+        onEventLog?.("info", "export-all cancelled");
+        return;
+      }
       await invoke("authorize_export_directory", { path: folder });
 
       for (const pack of packResult.packs) {
         const filename = `bablusheed_pack_${pack.index + 1}_of_${packResult.packs.length}.txt`;
         const path = await join(folder, filename);
-        await invoke("write_file_content", { path, content: pack.content });
+        onEventLog?.("debug", `export-all write start path=${path}`);
+        await invoke("write_file_content", { content: pack.content, path });
+        onEventLog?.("debug", `export-all write success path=${path}`);
       }
+      onEventLog?.("info", `export-all success packs=${packResult.packs.length} dir=${folder}`);
     } catch (err) {
       console.error("Export all failed:", err);
+      onEventLog?.("error", `export-all failed err=${String(err)}`);
     } finally {
       setExportingAll(false);
     }

--- a/src/components/OutputPreview.tsx
+++ b/src/components/OutputPreview.tsx
@@ -1,17 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
-import { dirname, join } from "@tauri-apps/api/path";
-import { writeText } from "@tauri-apps/plugin-clipboard-manager";
-import { open, save } from "@tauri-apps/plugin-dialog";
-import {
-  Check,
-  ChevronDown,
-  ChevronRight,
-  Copy,
-  Download,
-  FileText,
-  Package,
-  X,
-} from "lucide-react";
+import { join } from "@tauri-apps/api/path";
+import { open } from "@tauri-apps/plugin-dialog";
+import { ChevronDown, ChevronRight, FileText, Package, X } from "lucide-react";
 import { useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { buildPackFileTokenMap } from "@/lib/output-preview";
@@ -28,16 +18,6 @@ interface OutputPreviewProps {
   onRenderSample?: (component: string, timestampMs: number) => void;
   onClose: () => void;
 }
-
-const DEFAULT_PROMPT = `You are reading a multi-file project pack.
-
-Instructions:
-- Each embedded file starts with a path marker like "// path/to/file.ext".
-- Use those markers to identify file boundaries and references.
-- Read packs in order (Pack 1, then Pack 2, ...).
-- If a file appears with ".part-N-of-M", treat parts as one continuous file in part order.
-- Cite exact file paths when referencing code in your answer.
-`;
 
 function PackManifest({
   filePaths,
@@ -71,134 +51,19 @@ function PackManifest({
 
 function PackContent({
   content,
-  packIndex,
-  totalPacks,
-  prompt,
   filePaths,
   tokenMap,
   packTokens,
 }: {
   content: string;
-  packIndex: number;
-  totalPacks: number;
-  prompt: string;
   filePaths: string[];
   tokenMap: Map<string, number>;
   packTokens: number;
 }) {
-  const [copied, setCopied] = useState(false);
-  const [copiedWithPrompt, setCopiedWithPrompt] = useState(false);
-  const [saved, setSaved] = useState(false);
-
-  const handleCopy = async (withPrompt: boolean) => {
-    try {
-      const text = withPrompt && prompt ? `${prompt}\n\n---\n\n${content}` : content;
-      await writeText(text);
-      if (withPrompt) {
-        setCopiedWithPrompt(true);
-        setTimeout(() => setCopiedWithPrompt(false), 2000);
-      } else {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-      }
-    } catch (err) {
-      console.error("Copy failed:", err);
-    }
-  };
-
-  const handleSave = async () => {
-    try {
-      const path = await save({
-        defaultPath: `bablusheed_pack_${packIndex + 1}_of_${totalPacks}.txt`,
-        filters: [{ name: "Text Files", extensions: ["txt"] }],
-      });
-      if (path) {
-        const exportDir = await dirname(path);
-        await invoke("authorize_export_directory", { path: exportDir });
-        await invoke("write_file_content", { path, content });
-        setSaved(true);
-        setTimeout(() => setSaved(false), 2000);
-      }
-    } catch (err) {
-      console.error("Save failed:", err);
-    }
-  };
-
   return (
     <div className="relative flex flex-col h-full">
       {/* Pack manifest */}
       <PackManifest filePaths={filePaths} tokenMap={tokenMap} totalTokens={packTokens} />
-
-      {/* Action buttons */}
-      <div className="flex items-center gap-1 mb-2 flex-wrap">
-        <button
-          type="button"
-          onClick={() => handleCopy(false)}
-          className={`inline-flex items-center gap-1 h-6 px-2 text-[11px] font-medium rounded border transition-colors ${
-            copied
-              ? "bg-emerald-50 border-emerald-200 text-emerald-600 dark:bg-emerald-900/20 dark:border-emerald-700 dark:text-emerald-400"
-              : "bg-background border-border text-muted-foreground hover:text-foreground hover:border-primary/50"
-          }`}
-        >
-          {copied ? (
-            <>
-              <Check className="h-3 w-3" />
-              Copied
-            </>
-          ) : (
-            <>
-              <Copy className="h-3 w-3" />
-              Copy Pack
-            </>
-          )}
-        </button>
-
-        {prompt && (
-          <button
-            type="button"
-            onClick={() => handleCopy(true)}
-            className={`inline-flex items-center gap-1 h-6 px-2 text-[11px] font-medium rounded border transition-colors ${
-              copiedWithPrompt
-                ? "bg-emerald-50 border-emerald-200 text-emerald-600 dark:bg-emerald-900/20 dark:border-emerald-700 dark:text-emerald-400"
-                : "bg-primary/10 border-primary/30 text-primary hover:bg-primary/20"
-            }`}
-          >
-            {copiedWithPrompt ? (
-              <>
-                <Check className="h-3 w-3" />
-                Copied!
-              </>
-            ) : (
-              <>
-                <Copy className="h-3 w-3" />
-                Copy + Prompt
-              </>
-            )}
-          </button>
-        )}
-
-        <button
-          type="button"
-          onClick={handleSave}
-          className={`inline-flex items-center gap-1 h-6 px-2 text-[11px] font-medium rounded border transition-colors ${
-            saved
-              ? "bg-emerald-50 border-emerald-200 text-emerald-600 dark:bg-emerald-900/20 dark:border-emerald-700 dark:text-emerald-400"
-              : "bg-background border-border text-muted-foreground hover:text-foreground hover:border-primary/50"
-          }`}
-        >
-          {saved ? (
-            <>
-              <Check className="h-3 w-3" />
-              Saved
-            </>
-          ) : (
-            <>
-              <Download className="h-3 w-3" />
-              Save
-            </>
-          )}
-        </button>
-      </div>
       <pre className="flex-1 text-[11px] font-mono bg-muted/30 border border-border rounded overflow-auto whitespace-pre-wrap break-all leading-relaxed p-3 text-foreground/80">
         {content}
       </pre>
@@ -223,7 +88,6 @@ export function OutputPreview({
     windowMs: 3000,
   });
 
-  const [prompt, setPrompt] = useState(DEFAULT_PROMPT);
   const [showHowTo, setShowHowTo] = useState(false);
   const [exportingAll, setExportingAll] = useState(false);
 
@@ -263,18 +127,20 @@ export function OutputPreview({
           </span>
         </div>
         <div className="flex items-center gap-1">
-          {packResult.packs.length > 1 && (
-            <button
-              type="button"
-              onClick={handleExportAll}
-              disabled={exportingAll}
-              className="inline-flex items-center gap-1 h-6 px-2 text-[11px] font-medium rounded border border-border bg-background text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors disabled:opacity-50"
-              title="Export all packs as .txt files"
-            >
-              <Package className="h-3 w-3" />
-              {exportingAll ? "Exporting..." : "Export All"}
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={handleExportAll}
+            disabled={exportingAll}
+            className="inline-flex items-center gap-1 h-6 px-2 text-[11px] font-medium rounded border border-border bg-background text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors disabled:opacity-50"
+            title={
+              packResult.packs.length > 1
+                ? "Export all packs as .txt files"
+                : "Export pack as .txt file"
+            }
+          >
+            <Package className="h-3 w-3" />
+            {exportingAll ? "Exporting..." : packResult.packs.length > 1 ? "Export All" : "Export"}
+          </button>
           <button
             type="button"
             onClick={onClose}
@@ -283,23 +149,6 @@ export function OutputPreview({
             <X className="h-3 w-3" />
           </button>
         </div>
-      </div>
-
-      {/* Prompt Builder */}
-      <div className="shrink-0 px-3 pt-2 pb-1 border-b border-border">
-        <label
-          htmlFor="prompt-builder"
-          className="block text-[10px] font-semibold text-muted-foreground uppercase tracking-widest mb-1"
-        >
-          Prompt (prepended to Pack 1 when copying)
-        </label>
-        <textarea
-          id="prompt-builder"
-          value={prompt}
-          onChange={(e) => setPrompt(e.target.value)}
-          placeholder="e.g. Please review this code for security vulnerabilities..."
-          className="w-full h-14 text-[11px] font-mono bg-muted/40 border border-border rounded px-2 py-1.5 resize-none focus:outline-none focus:ring-1 focus:ring-ring focus:bg-background placeholder:text-muted-foreground/40"
-        />
       </div>
 
       {/* Content */}
@@ -330,9 +179,6 @@ export function OutputPreview({
               <div className="flex-1 overflow-hidden flex flex-col">
                 <PackContent
                   content={pack.content}
-                  packIndex={pack.index}
-                  totalPacks={packResult.packs.length}
-                  prompt={pack.index === 0 ? prompt : ""}
                   filePaths={pack.filePaths}
                   tokenMap={fileTokenMap}
                   packTokens={pack.estimatedTokens}
@@ -359,7 +205,6 @@ export function OutputPreview({
             <li>Attach Pack 1 as a file (drag the .txt file or use the paperclip icon).</li>
             <li>If you have multiple packs, attach them all before sending.</li>
             <li>Paste your prompt and send.</li>
-            <li>Use "Copy + Prompt" to copy Pack 1 with your prompt already prepended.</li>
           </ol>
         )}
       </div>

--- a/src/components/PackOptions.tsx
+++ b/src/components/PackOptions.tsx
@@ -99,16 +99,16 @@ export function PackOptions({
   const autoAdvisoryMax = deriveAdvisoryMaxTokensPerFile(contextWindowTokens);
   const effectiveAdvisoryMax = resolveAdvisoryMaxTokensPerFile(
     options.maxTokensPerPackFile,
-    contextWindowTokens
+    contextWindowTokens,
   );
 
   // Files eligible as AST entry points
   const astEligibleFiles = selectedFiles.filter(
-    (f) => !f.isDir && AST_SUPPORTED_EXTENSIONS.has(f.extension.toLowerCase())
+    (f) => !f.isDir && AST_SUPPORTED_EXTENSIONS.has(f.extension.toLowerCase()),
   );
   const eligiblePathSet = useMemo(
     () => new Set(astEligibleFiles.map((f) => f.path)),
-    [astEligibleFiles]
+    [astEligibleFiles],
   );
 
   const update = (partial: Partial<PackOptionsType>) => {
@@ -179,7 +179,7 @@ export function PackOptions({
                       "py-1 text-[10px] font-medium rounded border transition-colors cursor-pointer",
                       options.outputFormat === fmt
                         ? "bg-primary text-primary-foreground border-primary shadow-sm"
-                        : "bg-transparent border-border text-muted-foreground hover:border-primary/50 hover:text-foreground"
+                        : "bg-transparent border-border text-muted-foreground hover:border-primary/50 hover:text-foreground",
                     )}
                   >
                     {fmt === "plaintext" ? "Plain" : "Markdown"}

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -22,10 +22,14 @@ export function TitleBar({ theme, onToggleTheme }: TitleBarProps) {
       className="flex items-center justify-between h-8 px-3 bg-card border-b border-border select-none shrink-0"
       style={{ minHeight: 32 }}
       onMouseDown={(e) => {
-        if (e.button !== 0) return;
+        if (e.button !== 0) {
+          return;
+        }
         const target = e.target as HTMLElement;
         // Don't drag if clicking a button or interactive element
-        if (target.closest("button")) return;
+        if (target.closest("button")) {
+          return;
+        }
         runWindowAction("startDragging", () => appWindow.startDragging());
       }}
     >

--- a/src/components/TokenBar.tsx
+++ b/src/components/TokenBar.tsx
@@ -58,8 +58,8 @@ export function TokenBar({
       // Rough estimate: comments are ~15% of code
       const savings = Math.round(usedTokens * 0.15);
       suggestions.push({
-        label: `Strip Comments saves ~${formatTokenCount(savings)}`,
         action: () => onApplyOptimization({ stripComments: true }),
+        label: `Strip Comments saves ~${formatTokenCount(savings)}`,
       });
     }
 
@@ -71,8 +71,8 @@ export function TokenBar({
       if (mdTokens > 0) {
         const savings = Math.round(mdTokens * 0.3);
         suggestions.push({
-          label: `Minify Markdown saves ~${formatTokenCount(savings)}`,
           action: () => onApplyOptimization({ minifyMarkdown: true }),
+          label: `Minify Markdown saves ~${formatTokenCount(savings)}`,
         });
       }
     }
@@ -80,13 +80,13 @@ export function TokenBar({
     // Suggestion: Deselect 2 heaviest files
     if (onDeselectHeaviest && selectedFilePaths.length >= 2) {
       const sorted = [...selectedFilePaths].sort(
-        (a, b) => (tokenMap.get(b) ?? 0) - (tokenMap.get(a) ?? 0)
+        (a, b) => (tokenMap.get(b) ?? 0) - (tokenMap.get(a) ?? 0),
       );
       const top2Tokens = (tokenMap.get(sorted[0]) ?? 0) + (tokenMap.get(sorted[1]) ?? 0);
       if (top2Tokens > 0) {
         suggestions.push({
-          label: `Deselect 2 heaviest files saves ~${formatTokenCount(top2Tokens)}`,
           action: () => onDeselectHeaviest(2),
+          label: `Deselect 2 heaviest files saves ~${formatTokenCount(top2Tokens)}`,
         });
       }
     }
@@ -110,7 +110,7 @@ export function TokenBar({
                 ? "bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400"
                 : isWarning
                   ? "bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
-                  : "bg-muted text-muted-foreground"
+                  : "bg-muted text-muted-foreground",
             )}
           >
             {percentage.toFixed(0)}%
@@ -127,7 +127,7 @@ export function TokenBar({
           className={cn(
             "h-full rounded-full transition-all duration-300",
             barColor,
-            percentage >= 60 && "bg-linear-to-r from-emerald-500 via-yellow-400 to-red-500"
+            percentage >= 60 && "bg-linear-to-r from-emerald-500 via-yellow-400 to-red-500",
           )}
           style={{ width: `${percentage}%` }}
         />
@@ -141,7 +141,7 @@ export function TokenBar({
               ? "border-red-400/40 bg-red-500/10 text-red-700 dark:text-red-300"
               : perPackStatus.level === "warn"
                 ? "border-amber-400/40 bg-amber-500/10 text-amber-700 dark:text-amber-300"
-                : "border-emerald-400/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+                : "border-emerald-400/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
           )}
         >
           <div className="flex items-center justify-between gap-2">

--- a/src/components/TopHeavyFiles.tsx
+++ b/src/components/TopHeavyFiles.tsx
@@ -20,7 +20,9 @@ export function TopHeavyFiles({ selectedFiles, tokenMap, onFileClick }: TopHeavy
 
   const maxTokens = filesWithTokens[0]?.tokens ?? 1;
 
-  if (filesWithTokens.length === 0) return null;
+  if (filesWithTokens.length === 0) {
+    return null;
+  }
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
@@ -60,7 +62,7 @@ export function TopHeavyFiles({ selectedFiles, tokenMap, onFileClick }: TopHeavy
                 <span
                   className={cn(
                     "text-[11px] font-mono truncate flex-1 group-hover:text-foreground transition-colors",
-                    textColor
+                    textColor,
                   )}
                   title={file.relativePath}
                 >

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -5,20 +5,20 @@ import { cn } from "@/lib/utils";
 const badgeVariants = cva(
   "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
-    variants: {
-      variant: {
-        default: "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
-        secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        destructive:
-          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
-        outline: "text-foreground",
-      },
-    },
     defaultVariants: {
       variant: "default",
     },
-  }
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        outline: "text-foreground",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+      },
+    },
+  },
 );
 
 export interface BadgeProps

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,28 +5,28 @@ import { cn } from "@/lib/utils";
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
   {
+    defaultVariants: {
+      size: "default",
+      variant: "default",
+    },
     variants: {
+      size: {
+        default: "h-9 px-4 py-2",
+        icon: "h-9 w-9",
+        lg: "h-10 rounded-md px-8",
+        sm: "h-8 rounded-md px-3 text-xs",
+      },
       variant: {
         default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
         destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
         outline:
           "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
         secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
       },
     },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
+  },
 );
 
 export interface ButtonProps
@@ -36,9 +36,9 @@ export interface ButtonProps
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, ...props }, ref) => {
     return (
-      <button className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+      <button className={cn(buttonVariants({ className, size, variant }))} ref={ref} {...props} />
     );
-  }
+  },
 );
 Button.displayName = "Button";
 

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -9,7 +9,7 @@ interface CheckboxProps
   indeterminate?: boolean;
 }
 
-const Checkbox = React.forwardRef<React.ElementRef<typeof CheckboxPrimitive.Root>, CheckboxProps>(
+const Checkbox = React.forwardRef<React.ComponentRef<typeof CheckboxPrimitive.Root>, CheckboxProps>(
   ({ className, indeterminate, checked, ...props }, ref) => (
     <CheckboxPrimitive.Root
       ref={ref}
@@ -17,7 +17,7 @@ const Checkbox = React.forwardRef<React.ElementRef<typeof CheckboxPrimitive.Root
       indeterminate={indeterminate}
       className={cn(
         "peer inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:bg-primary data-[checked]:text-primary-foreground data-[indeterminate]:bg-primary data-[indeterminate]:text-primary-foreground",
-        className
+        className,
       )}
       {...props}
     >
@@ -25,7 +25,7 @@ const Checkbox = React.forwardRef<React.ElementRef<typeof CheckboxPrimitive.Root
         {indeterminate ? <Minus className="h-3 w-3" /> : <Check className="h-3 w-3" />}
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
-  )
+  ),
 );
 Checkbox.displayName = "Checkbox";
 

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
 );
 
 const Label = React.forwardRef<

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const ScrollArea = React.forwardRef<
-  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentRef<typeof ScrollAreaPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
 >(({ className, children, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
@@ -21,7 +21,7 @@ const ScrollArea = React.forwardRef<
 ScrollArea.displayName = "ScrollArea";
 
 const ScrollBar = React.forwardRef<
-  React.ElementRef<typeof ScrollAreaPrimitive.Scrollbar>,
+  React.ComponentRef<typeof ScrollAreaPrimitive.Scrollbar>,
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Scrollbar>
 >(({ className, orientation = "vertical", ...props }, ref) => (
   <ScrollAreaPrimitive.Scrollbar
@@ -31,7 +31,7 @@ const ScrollBar = React.forwardRef<
       "flex touch-none select-none transition-colors",
       orientation === "vertical" && "h-full w-2.5 border-l border-l-transparent p-[1px]",
       orientation === "horizontal" && "h-2.5 flex-col border-t border-t-transparent p-[1px]",
-      className
+      className,
     )}
     {...props}
   >

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -8,7 +8,7 @@ const SelectGroup = SelectPrimitive.Group;
 const SelectValue = SelectPrimitive.Value;
 
 const SelectTrigger = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentRef<typeof SelectPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
 >(({ className, children, ...props }, ref) => (
   <SelectPrimitive.Trigger
@@ -16,7 +16,7 @@ const SelectTrigger = React.forwardRef<
     data-slot="select-trigger"
     className={cn(
       "flex h-7 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-background px-2.5 py-1 text-xs shadow-none ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 hover:border-primary/50 transition-colors",
-      className
+      className,
     )}
     {...props}
   >
@@ -29,7 +29,7 @@ const SelectTrigger = React.forwardRef<
 SelectTrigger.displayName = "SelectTrigger";
 
 const SelectScrollUpButton = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.ScrollUpArrow>,
+  React.ComponentRef<typeof SelectPrimitive.ScrollUpArrow>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpArrow>
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollUpArrow
@@ -43,7 +43,7 @@ const SelectScrollUpButton = React.forwardRef<
 SelectScrollUpButton.displayName = "SelectScrollUpButton";
 
 const SelectScrollDownButton = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.ScrollDownArrow>,
+  React.ComponentRef<typeof SelectPrimitive.ScrollDownArrow>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownArrow>
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollDownArrow
@@ -63,7 +63,7 @@ interface SelectContentProps extends React.ComponentPropsWithoutRef<typeof Selec
 }
 
 const SelectContent = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Popup>,
+  React.ComponentRef<typeof SelectPrimitive.Popup>,
   SelectContentProps
 >(({ className, children, position = "popper", sideOffset = 4, ...props }, ref) => (
   <SelectPrimitive.Portal>
@@ -78,7 +78,7 @@ const SelectContent = React.forwardRef<
         className={cn(
           "max-h-80 min-w-[var(--anchor-width)] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-xl isolate",
           "data-[ending-style]:opacity-0 data-[starting-style]:opacity-0",
-          className
+          className,
         )}
         {...props}
       >
@@ -94,7 +94,7 @@ const SelectContent = React.forwardRef<
 SelectContent.displayName = "SelectContent";
 
 const SelectLabel = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.GroupLabel>,
+  React.ComponentRef<typeof SelectPrimitive.GroupLabel>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.GroupLabel>
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.GroupLabel
@@ -106,7 +106,7 @@ const SelectLabel = React.forwardRef<
 SelectLabel.displayName = "SelectLabel";
 
 const SelectItem = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
 >(({ className, children, ...props }, ref) => (
   <SelectPrimitive.Item
@@ -114,7 +114,7 @@ const SelectItem = React.forwardRef<
     data-slot="select-item"
     className={cn(
       "relative flex w-full select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-xs outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground",
-      className
+      className,
     )}
     {...props}
   >
@@ -129,7 +129,7 @@ const SelectItem = React.forwardRef<
 SelectItem.displayName = "SelectItem";
 
 const SelectSeparator = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentRef<typeof SelectPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -6,7 +6,7 @@ interface SeparatorProps extends React.ComponentPropsWithoutRef<typeof Separator
   decorative?: boolean;
 }
 
-const Separator = React.forwardRef<React.ElementRef<typeof SeparatorPrimitive>, SeparatorProps>(
+const Separator = React.forwardRef<React.ComponentRef<typeof SeparatorPrimitive>, SeparatorProps>(
   ({ className, orientation = "horizontal", decorative: _decorative = true, ...props }, ref) => (
     <SeparatorPrimitive
       ref={ref}
@@ -14,11 +14,11 @@ const Separator = React.forwardRef<React.ElementRef<typeof SeparatorPrimitive>, 
       className={cn(
         "shrink-0 bg-border",
         orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  ),
 );
 Separator.displayName = "Separator";
 

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -18,7 +18,7 @@ interface SliderProps
   disabled?: boolean;
   onValueChange?: (
     value: number[],
-    details: Parameters<NonNullable<SliderRootProps["onValueChange"]>>[1]
+    details: Parameters<NonNullable<SliderRootProps["onValueChange"]>>[1],
   ) => void;
 }
 
@@ -35,7 +35,7 @@ const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
       onValueChange,
       ...rootProps
     },
-    ref
+    ref,
   ) => {
     const thumbCount = Math.max(value?.length ?? defaultValue?.length ?? 1, 1);
 
@@ -68,7 +68,7 @@ const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
         </SliderPrimitive.Control>
       </SliderPrimitive.Root>
     );
-  }
+  },
 );
 Slider.displayName = "Slider";
 

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -3,20 +3,20 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const Switch = React.forwardRef<
-  React.ElementRef<typeof SwitchPrimitive.Root>,
+  React.ComponentRef<typeof SwitchPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>
 >(({ className, ...props }, ref) => (
   <SwitchPrimitive.Root
     ref={ref}
     className={cn(
       "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-border bg-zinc-300 shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-700 data-[checked]:border-primary data-[checked]:bg-primary",
-      className
+      className,
     )}
     {...props}
   >
     <SwitchPrimitive.Thumb
       className={cn(
-        "pointer-events-none block h-4 w-4 rounded-full bg-white shadow transition-transform data-[checked]:translate-x-4 data-[unchecked]:translate-x-0"
+        "pointer-events-none block h-4 w-4 rounded-full bg-white shadow transition-transform data-[checked]:translate-x-4 data-[unchecked]:translate-x-0",
       )}
     />
   </SwitchPrimitive.Root>

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -5,14 +5,14 @@ import { cn } from "@/lib/utils";
 const Tabs = TabsPrimitive.Root;
 
 const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.List
     ref={ref}
     className={cn(
       "inline-flex h-8 items-center justify-center rounded-md bg-muted p-0.5 text-muted-foreground",
-      className
+      className,
     )}
     {...props}
   />
@@ -20,14 +20,14 @@ const TabsList = React.forwardRef<
 TabsList.displayName = "TabsList";
 
 const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Tab>,
+  React.ComponentRef<typeof TabsPrimitive.Tab>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Tab>
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.Tab
     ref={ref}
     className={cn(
       "inline-flex items-center justify-center whitespace-nowrap rounded px-2.5 py-1 text-xs font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[selected]:bg-background data-[selected]:text-foreground data-[selected]:shadow-sm",
-      className
+      className,
     )}
     {...props}
   />
@@ -35,14 +35,14 @@ const TabsTrigger = React.forwardRef<
 TabsTrigger.displayName = "TabsTrigger";
 
 const TabsContent = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Panel>,
+  React.ComponentRef<typeof TabsPrimitive.Panel>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Panel>
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.Panel
     ref={ref}
     className={cn(
       "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-      className
+      className,
     )}
     {...props}
   />

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -21,7 +21,7 @@ interface TooltipContentProps
 }
 
 const TooltipContent = React.forwardRef<
-  React.ElementRef<typeof TooltipPrimitive.Popup>,
+  React.ComponentRef<typeof TooltipPrimitive.Popup>,
   TooltipContentProps
 >(({ className, sideOffset = 4, side = "top", ...props }, ref) => (
   <TooltipPrimitive.Portal>
@@ -31,7 +31,7 @@ const TooltipContent = React.forwardRef<
         className={cn(
           "overflow-hidden rounded border border-border bg-popover px-2.5 py-1.5 text-xs text-popover-foreground shadow-md",
           "data-[ending-style]:opacity-0 data-[starting-style]:opacity-0",
-          className
+          className,
         )}
         {...props}
       />

--- a/src/hooks/useFileTree.ts
+++ b/src/hooks/useFileTree.ts
@@ -5,17 +5,17 @@ function buildTreeNodes(nodes: FileNode[], depth: number): FileTreeNode[] {
   return nodes.map((node) => ({
     ...node,
     checkState: "unchecked" as CheckState,
-    tokenCount: 0,
+    children: node.children ? buildTreeNodes(node.children, depth + 1) : undefined,
     depth,
     isExpanded: depth < 2,
-    children: node.children ? buildTreeNodes(node.children, depth + 1) : undefined,
+    tokenCount: 0,
   }));
 }
 
 function updateCheckStateInTree(
   nodes: FileTreeNode[],
   targetId: string,
-  newState: "checked" | "unchecked"
+  newState: "checked" | "unchecked",
 ): FileTreeNode[] {
   return nodes.map((node) => {
     if (node.id === targetId) {
@@ -28,7 +28,7 @@ function updateCheckStateInTree(
     if (node.children) {
       const updatedChildren = updateCheckStateInTree(node.children, targetId, newState);
       const childState = computeParentState(updatedChildren);
-      return { ...node, children: updatedChildren, checkState: childState };
+      return { ...node, checkState: childState, children: updatedChildren };
     }
     return node;
   });
@@ -43,11 +43,17 @@ function setAllChildren(nodes: FileTreeNode[], state: "checked" | "unchecked"): 
 }
 
 function computeParentState(children: FileTreeNode[]): CheckState {
-  if (children.length === 0) return "unchecked";
+  if (children.length === 0) {
+    return "unchecked";
+  }
   const allChecked = children.every((c) => c.checkState === "checked");
   const noneChecked = children.every((c) => c.checkState === "unchecked");
-  if (allChecked) return "checked";
-  if (noneChecked) return "unchecked";
+  if (allChecked) {
+    return "checked";
+  }
+  if (noneChecked) {
+    return "unchecked";
+  }
   return "indeterminate";
 }
 
@@ -67,9 +73,9 @@ function flattenTree(nodes: FileTreeNode[]): FlatTreeItem[] {
   const result: FlatTreeItem[] = [];
   for (const node of nodes) {
     result.push({
-      node,
       depth: node.depth,
       hasChildren: Boolean(node.children && node.children.length > 0),
+      node,
     });
     if (node.isExpanded && node.children) {
       result.push(...flattenTree(node.children));
@@ -94,15 +100,15 @@ function getSelectedFiles(nodes: FileTreeNode[]): FileTreeNode[] {
 function updateTokensInTree(nodes: FileTreeNode[], tokenMap: Map<string, number>): FileTreeNode[] {
   return nodes.map((node) => ({
     ...node,
-    tokenCount: tokenMap.get(node.path) ?? node.tokenCount,
     children: node.children ? updateTokensInTree(node.children, tokenMap) : undefined,
+    tokenCount: tokenMap.get(node.path) ?? node.tokenCount,
   }));
 }
 
 function selectAllInTree(
   nodes: FileTreeNode[],
   selected: boolean,
-  filteredPaths?: Set<string>
+  filteredPaths?: Set<string>,
 ): FileTreeNode[] {
   const state: "checked" | "unchecked" = selected ? "checked" : "unchecked";
   return nodes.map((node) => {
@@ -119,7 +125,7 @@ function selectAllInTree(
       if (node.children) {
         const updatedChildren = selectAllInTree(node.children, selected, filteredPaths);
         const childState = computeParentState(updatedChildren);
-        return { ...node, children: updatedChildren, checkState: childState };
+        return { ...node, checkState: childState, children: updatedChildren };
       }
       return node;
     }
@@ -188,10 +194,18 @@ function isTestFile(node: FileTreeNode): boolean {
 }
 
 function isSourceFile(node: FileTreeNode): boolean {
-  if (isTestFile(node)) return false;
-  if (CONFIG_EXTENSIONS.has(node.extension.toLowerCase())) return false;
-  if (CONFIG_NAMES.has(node.name.toLowerCase())) return false;
-  if (DOC_EXTENSIONS.has(node.extension.toLowerCase())) return false;
+  if (isTestFile(node)) {
+    return false;
+  }
+  if (CONFIG_EXTENSIONS.has(node.extension.toLowerCase())) {
+    return false;
+  }
+  if (CONFIG_NAMES.has(node.name.toLowerCase())) {
+    return false;
+  }
+  if (DOC_EXTENSIONS.has(node.extension.toLowerCase())) {
+    return false;
+  }
   return SOURCE_EXTENSIONS.has(node.extension.toLowerCase());
 }
 
@@ -209,7 +223,7 @@ function quickSelectInTree(nodes: FileTreeNode[], filter: QuickFilter): FileTree
     if (node.isDir) {
       const updatedChildren = node.children ? quickSelectInTree(node.children, filter) : undefined;
       const childState = updatedChildren ? computeParentState(updatedChildren) : node.checkState;
-      return { ...node, children: updatedChildren, checkState: childState };
+      return { ...node, checkState: childState, children: updatedChildren };
     }
 
     if (filter === "clear") {
@@ -265,10 +279,14 @@ export function useFileTree() {
     setRootNodes((prev) => {
       const findNode = (nodes: FileTreeNode[]): FileTreeNode | undefined => {
         for (const n of nodes) {
-          if (n.id === nodeId) return n;
+          if (n.id === nodeId) {
+            return n;
+          }
           if (n.children) {
             const found = findNode(n.children);
-            if (found) return found;
+            if (found) {
+              return found;
+            }
           }
         }
         return undefined;
@@ -309,19 +327,19 @@ export function useFileTree() {
   }
 
   return {
-    rootNodes,
     flatItems,
-    selectedFiles,
-    searchQuery,
     highlightedPath,
-    visibleFilePaths,
     loadTree,
+    quickSelect,
+    rootNodes,
+    searchQuery,
+    selectAll,
+    selectedFiles,
+    setHighlightedPath,
+    setSearchQuery,
     toggleCheck,
     toggleExpand,
     updateTokens,
-    selectAll,
-    quickSelect,
-    setSearchQuery,
-    setHighlightedPath,
+    visibleFilePaths,
   };
 }

--- a/src/hooks/usePackager.ts
+++ b/src/hooks/usePackager.ts
@@ -13,7 +13,8 @@ export function usePackager(
   fileContents: Map<string, string>,
   llmProfileId: string,
   contextWindowTokens: number,
-  tokenMap?: Map<string, number>
+  tokenMap?: Map<string, number>,
+  onLog?: (level: "error" | "info" | "debug", message: string) => void,
 ) {
   const [packResult, setPackResult] = useState<PackResponse | null>(null);
   const [isPacking, setIsPacking] = useState(false);
@@ -21,16 +22,24 @@ export function usePackager(
   const [packWarnings, setPackWarnings] = useState<string[]>([]);
 
   const pack = async (options: PackOptions) => {
-    if (selectedFiles.length === 0) return;
+    if (selectedFiles.length === 0) {
+      return;
+    }
 
     setIsPacking(true);
     setPackError(null);
     setPackWarnings([]);
+    onLog?.(
+      "info",
+      `pack start selected=${selectedFiles.filter((f) => !f.isDir).length} llm=${llmProfileId} numPacks=${options.numPacks} format=${options.outputFormat} ast=${options.astDeadCode && !!options.entryPoint}`,
+    );
 
     try {
       const rawContentMap = new Map<string, string>();
       for (const file of selectedFiles) {
-        if (file.isDir) continue;
+        if (file.isDir) {
+          continue;
+        }
         const rawContent = fileContents.get(file.path) ?? "";
         rawContentMap.set(file.path, rawContent);
       }
@@ -39,10 +48,27 @@ export function usePackager(
         options.astDeadCode && options.entryPoint
           ? await applyAstDeadCode(selectedFiles, rawContentMap, options.entryPoint)
           : rawContentMap;
+      if (options.astDeadCode && options.entryPoint) {
+        let changedFiles = 0;
+        let charDelta = 0;
+        for (const [path, raw] of rawContentMap) {
+          const processed = astProcessedContentMap.get(path) ?? "";
+          if (processed !== raw) {
+            changedFiles += 1;
+            charDelta += processed.length - raw.length;
+          }
+        }
+        onLog?.(
+          "info",
+          `pack ast processed files=${rawContentMap.size} changed=${changedFiles} charDelta=${charDelta}`,
+        );
+      }
 
       const contentMap = new Map<string, string>();
       for (const file of selectedFiles) {
-        if (file.isDir) continue;
+        if (file.isDir) {
+          continue;
+        }
         const baseContent = astProcessedContentMap.get(file.path) ?? "";
         let content = baseContent;
         const ext = file.extension.toLowerCase();
@@ -57,7 +83,7 @@ export function usePackager(
           content = minifyMarkdown(
             content,
             options.stripMarkdownHeadings,
-            options.stripMarkdownBlockquotes
+            options.stripMarkdownBlockquotes,
           );
         }
         contentMap.set(file.path, content);
@@ -66,30 +92,43 @@ export function usePackager(
       const files = selectedFiles
         .filter((f) => !f.isDir)
         .map((file) => ({
-          path: file.relativePath,
           content: contentMap.get(file.path) ?? "",
+          path: file.relativePath,
           tokenCount: tokenMap?.get(file.path),
         }));
 
       const advisoryMaxTokensPerFile = resolveAdvisoryMaxTokensPerFile(
         options.maxTokensPerPackFile,
-        contextWindowTokens
+        contextWindowTokens,
       );
       const balanced = splitOversizedFilesForPacking(files, advisoryMaxTokensPerFile);
       setPackWarnings(balanced.warnings);
+      if (balanced.warnings.length > 0) {
+        onLog?.("info", `pack warnings count=${balanced.warnings.length}`);
+      }
+      onLog?.(
+        "debug",
+        `pack balancing filesIn=${files.length} filesOut=${balanced.files.length} splitFiles=${balanced.splitFileCount} generatedParts=${balanced.generatedPartCount}`,
+      );
 
       const result = await invoke<PackResponse>("pack_files", {
         request: {
           files: balanced.files,
+          llmProfileId,
           numPacks: options.numPacks,
           outputFormat: options.outputFormat,
-          llmProfileId,
         },
       });
 
       setPackResult(result);
+      onLog?.(
+        "info",
+        `pack success packs=${result.packs.length} totalTokens=${result.totalTokens}`,
+      );
     } catch (err) {
-      setPackError(err instanceof Error ? err.message : String(err));
+      const message = err instanceof Error ? err.message : String(err);
+      setPackError(message);
+      onLog?.("error", `pack failed err=${message}`);
     } finally {
       setIsPacking(false);
     }
@@ -101,5 +140,5 @@ export function usePackager(
     setPackWarnings([]);
   };
 
-  return { packResult, isPacking, packError, packWarnings, pack, clearResult };
+  return { clearResult, isPacking, pack, packError, packResult, packWarnings };
 }

--- a/src/hooks/useTokenCount.ts
+++ b/src/hooks/useTokenCount.ts
@@ -31,9 +31,13 @@ interface AstCache {
 }
 
 function areStringMapsEqual(a: Map<string, string>, b: Map<string, string>): boolean {
-  if (a.size !== b.size) return false;
+  if (a.size !== b.size) {
+    return false;
+  }
   for (const [key, value] of a) {
-    if (b.get(key) !== value) return false;
+    if (b.get(key) !== value) {
+      return false;
+    }
   }
   return true;
 }
@@ -45,7 +49,8 @@ export function useTokenCount(
   packOptions: PackOptions,
   debugEnabled = false,
   onDebugLog?: (line: string) => void,
-  onDebugMetric?: (name: "astRecompute" | "astCacheHit" | "workerQueued" | "workerResult") => void
+  onDebugMetric?: (name: "astRecompute" | "astCacheHit" | "workerQueued" | "workerResult") => void,
+  onEventLog?: (level: "error" | "info" | "debug", message: string) => void,
 ) {
   const [tokenMap, setTokenMap] = useState<Map<string, number>>(new Map());
   const [isCalculating, setIsCalculating] = useState(false);
@@ -64,6 +69,7 @@ export function useTokenCount(
   const debugEnabledRef = useRef(debugEnabled);
   const debugLogRef = useRef<((line: string) => void) | null>(onDebugLog ?? null);
   const onDebugMetricRef = useRef(onDebugMetric);
+  const onEventLogRef = useRef(onEventLog);
 
   useEffect(() => {
     tokenMapRef.current = tokenMap;
@@ -81,8 +87,14 @@ export function useTokenCount(
     onDebugMetricRef.current = onDebugMetric;
   }, [onDebugMetric]);
 
+  useEffect(() => {
+    onEventLogRef.current = onEventLog;
+  }, [onEventLog]);
+
   const logDebug = useCallback((message: string) => {
-    if (!debugEnabledRef.current) return;
+    if (!debugEnabledRef.current) {
+      return;
+    }
     debugLogRef.current?.(`[${new Date().toISOString()}] ${message}`);
   }, []);
 
@@ -100,8 +112,15 @@ export function useTokenCount(
       type: "module",
     });
 
+    workerRef.current.onerror = (event) => {
+      const message = event.message || "unknown worker error";
+      onEventLogRef.current?.("error", `token-count worker error err=${message}`);
+    };
+
     workerRef.current.onmessage = (event: MessageEvent<WorkerResult>) => {
-      if (event.data.type !== "result") return;
+      if (event.data.type !== "result") {
+        return;
+      }
 
       const { requestId, results } = event.data;
       const latestRequestId = latestRequestIdRef.current;
@@ -123,9 +142,13 @@ export function useTokenCount(
         const before = prevTokens.get(path) ?? 0;
         const delta = tokens - before;
         deltaTotal += delta;
-        if (delta > 0) increased += 1;
-        else if (delta < 0) decreased += 1;
-        else unchanged += 1;
+        if (delta > 0) {
+          increased += 1;
+        } else if (delta < 0) {
+          decreased += 1;
+        } else {
+          unchanged += 1;
+        }
       }
 
       setTokenMap((prev) => {
@@ -143,13 +166,15 @@ export function useTokenCount(
       logDebug(
         `token-count result request=${requestId} files=${results.length} ` +
           `deltaTokens=${deltaTotal} increased=${increased} decreased=${decreased} unchanged=${unchanged} ` +
-          `charDelta=${charDelta} elapsedMs=${elapsedMs}`
+          `charDelta=${charDelta} elapsedMs=${elapsedMs}`,
       );
       onDebugMetricRef.current?.("workerResult");
     };
 
     return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
       workerRef.current?.terminate();
     };
   }, [logDebug]);
@@ -158,160 +183,203 @@ export function useTokenCount(
     let cancelled = false;
 
     const runCount = async () => {
-      logDebug(
-        `token-count run start selected=${selectedFilesRef.current.length} tokenizer=${llmProfile.tokenizer} ast=${packOptions.astDeadCode && !!packOptions.entryPoint}`
-      );
+      try {
+        logDebug(
+          `token-count run start selected=${selectedFilesRef.current.length} tokenizer=${llmProfile.tokenizer} ast=${packOptions.astDeadCode && !!packOptions.entryPoint}`,
+        );
 
-      const rawContents = new Map<string, string>();
-      for (const file of selectedFilesRef.current) {
-        const rawContent = fileContents.get(file.path);
-        if (rawContent === undefined || rawContent === null) continue;
-        rawContents.set(file.path, rawContent);
-      }
-
-      let astProcessedContents = rawContents;
-      if (packOptions.astDeadCode && packOptions.entryPoint) {
-        const cached = astCacheRef.current;
-        if (
-          cached &&
-          cached.entryPoint === packOptions.entryPoint &&
-          cached.selectedIdentityKey === selectedIdentityKey &&
-          areStringMapsEqual(cached.rawContents, rawContents)
-        ) {
-          astProcessedContents = cached.result;
-          logDebug(`token-count ast cache hit files=${rawContents.size}`);
-          onDebugMetricRef.current?.("astCacheHit");
-        } else {
-          astProcessedContents = await applyAstDeadCode(
-            selectedFilesRef.current,
-            rawContents,
-            packOptions.entryPoint
-          );
-          if (cancelled) return;
-          astCacheRef.current = {
-            entryPoint: packOptions.entryPoint,
-            selectedIdentityKey,
-            rawContents: new Map(rawContents),
-            result: new Map(astProcessedContents),
-          };
-          logDebug(`token-count ast recompute files=${rawContents.size}`);
-          onDebugMetricRef.current?.("astRecompute");
-        }
-      } else if (astCacheRef.current) {
-        astCacheRef.current = null;
-      }
-
-      if (cancelled) return;
-
-      const countedContents = new Map<string, string>();
-      for (const file of selectedFilesRef.current) {
-        const baseContent = astProcessedContents.get(file.path);
-        if (baseContent === undefined || baseContent === null) continue;
-
-        let content = baseContent;
-        const ext = file.extension.toLowerCase();
-        if (packOptions.stripComments) {
-          content = stripComments(content, ext);
-        }
-        if (packOptions.reduceWhitespace) {
-          content = reduceWhitespace(content, ext, file.relativePath);
-        }
-        if (packOptions.minifyMarkdown && (ext === "md" || ext === "mdx")) {
-          content = minifyMarkdown(
-            content,
-            packOptions.stripMarkdownHeadings,
-            packOptions.stripMarkdownBlockquotes
-          );
-        }
-        countedContents.set(file.path, content);
-      }
-
-      const tokenizerChanged = lastTokenizerRef.current !== llmProfile.tokenizer;
-      const optimizationKey = [
-        packOptions.stripComments,
-        packOptions.reduceWhitespace,
-        packOptions.minifyMarkdown,
-        packOptions.stripMarkdownHeadings,
-        packOptions.stripMarkdownBlockquotes,
-        packOptions.astDeadCode,
-        packOptions.entryPoint ?? "",
-      ].join("|");
-      const optimizationChanged = lastOptimizationKeyRef.current !== optimizationKey;
-
-      if (tokenizerChanged || optimizationChanged) {
-        contentHashMapRef.current.clear();
-        lastTokenizerRef.current = llmProfile.tokenizer;
-        lastOptimizationKeyRef.current = optimizationKey;
-      }
-
-      const newPending = new Map<string, string>();
-      for (const [path, content] of countedContents) {
-        const lastContent = contentHashMapRef.current.get(path);
-        if (lastContent !== content) {
-          newPending.set(path, content);
-          contentHashMapRef.current.set(path, content);
-        }
-      }
-
-      for (const key of contentHashMapRef.current.keys()) {
-        if (!countedContents.has(key)) {
-          contentHashMapRef.current.delete(key);
-        }
-      }
-
-      if (newPending.size === 0) return;
-
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(() => {
-        if (cancelled) return;
-        const files = Array.from(newPending.entries()).map(([path, content]) => ({
-          path,
-          content,
-        }));
-        if (files.length === 0) return;
-
-        const requestId = ++requestCounterRef.current;
-        latestRequestIdRef.current = requestId;
-
-        let rawChars = 0;
-        let optimizedChars = 0;
-        const prevTokens = new Map<string, number>();
-
-        for (const [path, content] of newPending) {
-          const raw = fileContents.get(path) ?? "";
-          rawChars += raw.length;
-          optimizedChars += content.length;
-          prevTokens.set(path, tokenMapRef.current.get(path) ?? 0);
+        if (selectedFilesRef.current.length === 0) {
+          if (debounceRef.current) {
+            clearTimeout(debounceRef.current);
+            debounceRef.current = null;
+          }
+          contentHashMapRef.current.clear();
+          requestMetaRef.current.clear();
+          astCacheRef.current = null;
+          setIsCalculating(false);
+          setTokenMap((prev) => {
+            if (prev.size === 0) {
+              return prev;
+            }
+            const next = new Map<string, number>();
+            tokenMapRef.current = next;
+            return next;
+          });
+          logDebug("token-count reset: empty selection");
+          return;
         }
 
-        requestMetaRef.current.set(requestId, {
-          sentAtMs: Date.now(),
-          fileCount: files.length,
-          rawChars,
-          optimizedChars,
-          prevTokens,
-        });
+        const rawContents = new Map<string, string>();
+        for (const file of selectedFilesRef.current) {
+          const rawContent = fileContents.get(file.path);
+          if (rawContent === undefined || rawContent === null) {
+            continue;
+          }
+          rawContents.set(file.path, rawContent);
+        }
 
-        // Keep request metadata map bounded.
-        const pruneBefore = requestId - 20;
-        for (const key of requestMetaRef.current.keys()) {
-          if (key < pruneBefore) {
-            requestMetaRef.current.delete(key);
+        let astProcessedContents = rawContents;
+        if (packOptions.astDeadCode && packOptions.entryPoint) {
+          const cached = astCacheRef.current;
+          if (
+            cached &&
+            cached.entryPoint === packOptions.entryPoint &&
+            cached.selectedIdentityKey === selectedIdentityKey &&
+            areStringMapsEqual(cached.rawContents, rawContents)
+          ) {
+            astProcessedContents = cached.result;
+            logDebug(`token-count ast cache hit files=${rawContents.size}`);
+            onDebugMetricRef.current?.("astCacheHit");
+          } else {
+            astProcessedContents = await applyAstDeadCode(
+              selectedFilesRef.current,
+              rawContents,
+              packOptions.entryPoint,
+            );
+            if (cancelled) {
+              return;
+            }
+            astCacheRef.current = {
+              entryPoint: packOptions.entryPoint,
+              rawContents: new Map(rawContents),
+              result: new Map(astProcessedContents),
+              selectedIdentityKey,
+            };
+            logDebug(`token-count ast recompute files=${rawContents.size}`);
+            onDebugMetricRef.current?.("astRecompute");
+          }
+        } else if (astCacheRef.current) {
+          astCacheRef.current = null;
+        }
+
+        if (cancelled) {
+          return;
+        }
+
+        const countedContents = new Map<string, string>();
+        for (const file of selectedFilesRef.current) {
+          const baseContent = astProcessedContents.get(file.path);
+          if (baseContent === undefined || baseContent === null) {
+            continue;
+          }
+
+          let content = baseContent;
+          const ext = file.extension.toLowerCase();
+          if (packOptions.stripComments) {
+            content = stripComments(content, ext);
+          }
+          if (packOptions.reduceWhitespace) {
+            content = reduceWhitespace(content, ext, file.relativePath);
+          }
+          if (packOptions.minifyMarkdown && (ext === "md" || ext === "mdx")) {
+            content = minifyMarkdown(
+              content,
+              packOptions.stripMarkdownHeadings,
+              packOptions.stripMarkdownBlockquotes,
+            );
+          }
+          countedContents.set(file.path, content);
+        }
+
+        const tokenizerChanged = lastTokenizerRef.current !== llmProfile.tokenizer;
+        const optimizationKey = [
+          packOptions.stripComments,
+          packOptions.reduceWhitespace,
+          packOptions.minifyMarkdown,
+          packOptions.stripMarkdownHeadings,
+          packOptions.stripMarkdownBlockquotes,
+          packOptions.astDeadCode,
+          packOptions.entryPoint ?? "",
+        ].join("|");
+        const optimizationChanged = lastOptimizationKeyRef.current !== optimizationKey;
+
+        if (tokenizerChanged || optimizationChanged) {
+          contentHashMapRef.current.clear();
+          lastTokenizerRef.current = llmProfile.tokenizer;
+          lastOptimizationKeyRef.current = optimizationKey;
+        }
+
+        const newPending = new Map<string, string>();
+        for (const [path, content] of countedContents) {
+          const lastContent = contentHashMapRef.current.get(path);
+          if (lastContent !== content) {
+            newPending.set(path, content);
+            contentHashMapRef.current.set(path, content);
           }
         }
 
-        setIsCalculating(true);
-        const strategy = getTokenizerEncoding(llmProfile.tokenizer);
-        const message: WorkerMessage = { type: "count", requestId, files, strategy };
-        workerRef.current?.postMessage(message);
-        onDebugMetricRef.current?.("workerQueued");
+        for (const key of contentHashMapRef.current.keys()) {
+          if (!countedContents.has(key)) {
+            contentHashMapRef.current.delete(key);
+          }
+        }
 
-        logDebug(
-          `token-count queued request=${requestId} files=${files.length} ` +
-            `rawChars=${rawChars} optimizedChars=${optimizedChars} charDelta=${optimizedChars - rawChars} ` +
-            `tokenizer=${llmProfile.tokenizer}`
-        );
-      }, 150);
+        if (newPending.size === 0) {
+          return;
+        }
+
+        if (debounceRef.current) {
+          clearTimeout(debounceRef.current);
+        }
+        debounceRef.current = setTimeout(() => {
+          if (cancelled) {
+            return;
+          }
+          const files = Array.from(newPending.entries()).map(([path, content]) => ({
+            content,
+            path,
+          }));
+          if (files.length === 0) {
+            return;
+          }
+
+          const requestId = ++requestCounterRef.current;
+          latestRequestIdRef.current = requestId;
+
+          let rawChars = 0;
+          let optimizedChars = 0;
+          const prevTokens = new Map<string, number>();
+
+          for (const [path, content] of newPending) {
+            const raw = fileContents.get(path) ?? "";
+            rawChars += raw.length;
+            optimizedChars += content.length;
+            prevTokens.set(path, tokenMapRef.current.get(path) ?? 0);
+          }
+
+          requestMetaRef.current.set(requestId, {
+            fileCount: files.length,
+            optimizedChars,
+            prevTokens,
+            rawChars,
+            sentAtMs: Date.now(),
+          });
+
+          // Keep request metadata map bounded.
+          const pruneBefore = requestId - 20;
+          for (const key of requestMetaRef.current.keys()) {
+            if (key < pruneBefore) {
+              requestMetaRef.current.delete(key);
+            }
+          }
+
+          setIsCalculating(true);
+          const strategy = getTokenizerEncoding(llmProfile.tokenizer);
+          const message: WorkerMessage = { files, requestId, strategy, type: "count" };
+          workerRef.current?.postMessage(message);
+          onDebugMetricRef.current?.("workerQueued");
+
+          logDebug(
+            `token-count queued request=${requestId} files=${files.length} ` +
+              `rawChars=${rawChars} optimizedChars=${optimizedChars} charDelta=${optimizedChars - rawChars} ` +
+              `tokenizer=${llmProfile.tokenizer}`,
+          );
+        }, 150);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        onEventLogRef.current?.("error", `token-count run failed err=${message}`);
+        setIsCalculating(false);
+      }
     };
 
     void runCount();
@@ -338,5 +406,5 @@ export function useTokenCount(
 
   const selectedTokens = selectedFiles.reduce((sum, f) => sum + (tokenMap.get(f.path) ?? 0), 0);
 
-  return { tokenMap, totalTokens: selectedTokens, isCalculating };
+  return { isCalculating, tokenMap, totalTokens: selectedTokens };
 }

--- a/src/lib/ast-reachability.test.ts
+++ b/src/lib/ast-reachability.test.ts
@@ -105,6 +105,17 @@ export default KeepDefault;
     expect(output).not.toContain("function DropFn");
   });
 
+  it("should preserve default-exported identifiers with trailing comments", () => {
+    const input = `const KeepDefault = () => 1;
+function DropFn() { return 2; }
+export default KeepDefault; // keep this default export
+`;
+    const output = run(input, ["KeepDefault", "DropFn"], "ts");
+    expect(output).toContain("const KeepDefault");
+    expect(output).toContain("export default KeepDefault;");
+    expect(output).not.toContain("function DropFn");
+  });
+
   it("should preserve TSX default-exported component identifiers", () => {
     const input = `import { cn } from '../lib/utils';
 

--- a/src/lib/ast-reachability.test.ts
+++ b/src/lib/ast-reachability.test.ts
@@ -94,6 +94,46 @@ export { KeepViaDefault as default };
     expect(output).not.toContain("DropViaDefault");
   });
 
+  it("should preserve default-exported identifiers referenced by export default statements", () => {
+    const input = `const KeepDefault = () => 1;
+function DropFn() { return 2; }
+export default KeepDefault;
+`;
+    const output = run(input, ["KeepDefault", "DropFn"], "ts");
+    expect(output).toContain("const KeepDefault");
+    expect(output).toContain("export default KeepDefault");
+    expect(output).not.toContain("function DropFn");
+  });
+
+  it("should preserve TSX default-exported component identifiers", () => {
+    const input = `import { cn } from '../lib/utils';
+
+type LimitIndicatorProps = { percent: number };
+
+const getColorClass = (percent: number): string => {
+  if (percent >= 85) return 'bg-red-500';
+  if (percent >= 60) return 'bg-amber-400';
+  return 'bg-emerald-400';
+};
+
+const LimitIndicator = ({ percent }: LimitIndicatorProps) => {
+  const safePercent = Number.isFinite(percent) ? percent : 0;
+  const clampedPercent = Math.max(0, Math.min(safePercent, 100));
+  return (
+    <div>
+      <div className={cn('h-full transition-all', getColorClass(clampedPercent))} />
+    </div>
+  );
+};
+
+export default LimitIndicator;
+`;
+    const output = run(input, ["LimitIndicator"], "tsx");
+    expect(output).toContain("const LimitIndicator");
+    expect(output).toContain("export default LimitIndicator");
+    expect(output).toContain("getColorClass");
+  });
+
   it("should remove non-exported const/function/class declarations when unreachable", () => {
     const input = `const deadConst = () => 1;
 function deadFn() { return 2; }

--- a/src/lib/ast-reachability.ts
+++ b/src/lib/ast-reachability.ts
@@ -22,7 +22,7 @@ function isLikelyExportedSymbol(content: string, symbol: string, ext: string): b
       new RegExp(`^\\s*export\\s+(?:const|let|var)\\s+${escaped}\\b`, "m"),
       new RegExp(`^\\s*export\\s+class\\s+${escaped}\\b`, "m"),
       new RegExp(`^\\s*export\\s*\\{[^}]*\\b${escaped}\\b[^}]*\\}`, "m"),
-      new RegExp(`^\\s*export\\s+default\\s+${escaped}\\s*;?\\s*$`, "m"),
+      new RegExp(`^\\s*export\\s+default\\s+${escaped}\\b`, "m"),
     ];
     return patterns.some((pattern) => pattern.test(content));
   }
@@ -51,12 +51,14 @@ function isLikelyExportedSymbol(content: string, symbol: string, ext: string): b
  * Uses regex-based approach for TS/JS/Python/Rust/Go.
  */
 export function stripUnreachableSymbols(content: string, symbols: string[], ext: string): string {
-  if (symbols.length === 0) return content;
+  if (symbols.length === 0) {
+    return content;
+  }
 
   // Skip regex stripping on large files to avoid pathological regex behavior.
   if (content.length > MAX_STRIP_SIZE) {
     console.warn(
-      `stripUnreachableSymbols: skipping ${ext} file (${content.length} chars > MAX_STRIP_SIZE ${MAX_STRIP_SIZE})`
+      `stripUnreachableSymbols: skipping ${ext} file (${content.length} chars > MAX_STRIP_SIZE ${MAX_STRIP_SIZE})`,
     );
     return content;
   }
@@ -73,54 +75,54 @@ export function stripUnreachableSymbols(content: string, symbols: string[], ext:
       result = result.replace(
         new RegExp(
           `(^|\\n)(?![ \\t])(?:async\\s+)?function\\s+${escaped}\\s*[(<][\\s\\S]*?(?=\\n(?![ \\t])(?:export|async\\s+function|function|const|let|var|class|interface|type|enum|//|/\\*|$)|$)`,
-          "g"
+          "g",
         ),
-        "$1"
+        "$1",
       );
       result = result.replace(
         new RegExp(
           `(^|\\n)(?![ \\t])(?:const|let|var)\\s+${escaped}\\s*=[\\s\\S]*?(?=\\n(?![ \\t])(?:export|async\\s+function|function|const|let|var|class|interface|type|enum|//|/\\*|$)|$)`,
-          "g"
+          "g",
         ),
-        "$1"
+        "$1",
       );
       result = result.replace(
         new RegExp(
           `(^|\\n)(?![ \\t])class\\s+${escaped}[\\s\\S]*?(?=\\n(?![ \\t])(?:export|async\\s+function|function|const|let|var|class|interface|type|enum|//|/\\*|$)|$)`,
-          "g"
+          "g",
         ),
-        "$1"
+        "$1",
       );
     } else if (ext === "py") {
       result = result.replace(
         new RegExp(
           `(^|\\n)(?![ \\t])def\\s+${escaped}\\s*\\([\\s\\S]*?(?=\\n(?![ \\t])(?:def\\s|class\\s)|$)`,
-          "g"
+          "g",
         ),
-        "$1"
+        "$1",
       );
       result = result.replace(
         new RegExp(
           `(^|\\n)(?![ \\t])class\\s+${escaped}[\\s\\S]*?(?=\\n(?![ \\t])(?:def\\s|class\\s)|$)`,
-          "g"
+          "g",
         ),
-        "$1"
+        "$1",
       );
     } else if (ext === "rs") {
       result = result.replace(
         new RegExp(
           `(^|\\n)(?![ \\t])(?:async\\s+)?fn\\s+${escaped}[\\s\\S]*?(?=\\n(?![ \\t])(?:pub|fn|struct|impl|enum|trait|use|mod|//|/\\*|$)|$)`,
-          "g"
+          "g",
         ),
-        "$1"
+        "$1",
       );
     } else if (ext === "go") {
       result = result.replace(
         new RegExp(
           `(^|\\n)(?![ \\t])func\\s+(?:\\([^)]+\\)\\s+)?${escaped}\\s*\\([^)]*\\)[\\s\\S]*?(?=\\n(?![ \\t])(?:func\\s|type\\s|var\\s|const\\s|import\\s|package\\s)|$)`,
-          "g"
+          "g",
         ),
-        "$1"
+        "$1",
       );
     }
   }
@@ -131,18 +133,22 @@ export function stripUnreachableSymbols(content: string, symbols: string[], ext:
 export async function applyAstDeadCode(
   selectedFiles: FileTreeNode[],
   contentMap: Map<string, string>,
-  entryPoint: string | null
+  entryPoint: string | null,
 ): Promise<Map<string, string>> {
-  if (!entryPoint) return contentMap;
+  if (!entryPoint) {
+    return contentMap;
+  }
 
   const astFiles = selectedFiles
     .filter((f) => !f.isDir && AST_SUPPORTED_EXTENSIONS.has(f.extension.toLowerCase()))
     .map((f) => ({
-      path: f.path,
       content: contentMap.get(f.path) ?? "",
+      path: f.path,
     }));
 
-  if (astFiles.length === 0) return contentMap;
+  if (astFiles.length === 0) {
+    return contentMap;
+  }
 
   try {
     const reachability = await invoke<ReachabilityResult>("analyze_reachability", {
@@ -152,14 +158,18 @@ export async function applyAstDeadCode(
 
     const next = new Map(contentMap);
     for (const file of selectedFiles) {
-      if (file.isDir) continue;
+      if (file.isDir) {
+        continue;
+      }
       const unreachable = reachability.unreachable_symbols[file.path];
-      if (!unreachable || unreachable.length === 0) continue;
+      if (!unreachable || unreachable.length === 0) {
+        continue;
+      }
 
       const current = next.get(file.path) ?? "";
       next.set(
         file.path,
-        stripUnreachableSymbols(current, unreachable, file.extension.toLowerCase())
+        stripUnreachableSymbols(current, unreachable, file.extension.toLowerCase()),
       );
     }
 

--- a/src/lib/ast-reachability.ts
+++ b/src/lib/ast-reachability.ts
@@ -22,6 +22,7 @@ function isLikelyExportedSymbol(content: string, symbol: string, ext: string): b
       new RegExp(`^\\s*export\\s+(?:const|let|var)\\s+${escaped}\\b`, "m"),
       new RegExp(`^\\s*export\\s+class\\s+${escaped}\\b`, "m"),
       new RegExp(`^\\s*export\\s*\\{[^}]*\\b${escaped}\\b[^}]*\\}`, "m"),
+      new RegExp(`^\\s*export\\s+default\\s+${escaped}\\s*;?\\s*$`, "m"),
     ];
     return patterns.some((pattern) => pattern.test(content));
   }

--- a/src/lib/llm-profiles.ts
+++ b/src/lib/llm-profiles.ts
@@ -99,7 +99,9 @@ export function getProfile(id: string): LLMProfile {
 }
 
 export function getTokenizerEncoding(tokenizer: LLMProfile["tokenizer"]): "openai" | "approx" {
-  if (tokenizer === "o200k") return "openai";
+  if (tokenizer === "o200k") {
+    return "openai";
+  }
   return "approx";
 }
 

--- a/src/lib/output-preview.ts
+++ b/src/lib/output-preview.ts
@@ -2,7 +2,7 @@ import type { PackItem } from "@/types";
 
 export function buildPackFileTokenMap(
   packs: PackItem[],
-  tokenMap?: Map<string, number>
+  tokenMap?: Map<string, number>,
 ): Map<string, number> {
   const fileTokenMap = new Map<string, number>();
 

--- a/src/lib/pack-strategy.ts
+++ b/src/lib/pack-strategy.ts
@@ -34,13 +34,19 @@ const MIN_BREAK_SCAN_RATIO = 0.35;
 const ADVISORY_WARN_RATIO = 0.85;
 
 function formatCompactTokenCount(tokens: number): string {
-  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
-  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}k`;
+  if (tokens >= 1_000_000) {
+    return `${(tokens / 1_000_000).toFixed(1)}M`;
+  }
+  if (tokens >= 1_000) {
+    return `${(tokens / 1_000).toFixed(1)}k`;
+  }
   return tokens.toString();
 }
 
 export function estimateTokens(content: string): number {
-  if (content.length === 0) return 0;
+  if (content.length === 0) {
+    return 0;
+  }
   return Math.max(Math.ceil(content.length / APPROX_CHARS_PER_TOKEN), 1);
 }
 
@@ -51,7 +57,7 @@ export function deriveAdvisoryMaxTokensPerFile(contextWindowTokens: number): num
 
 export function resolveAdvisoryMaxTokensPerFile(
   configuredValue: number | null | undefined,
-  contextWindowTokens: number
+  contextWindowTokens: number,
 ): number {
   if (configuredValue === null || configuredValue === undefined || configuredValue <= 0) {
     return deriveAdvisoryMaxTokensPerFile(contextWindowTokens);
@@ -60,21 +66,27 @@ export function resolveAdvisoryMaxTokensPerFile(
 }
 
 export function getEffectiveTokenCount(file: PackStrategyFile): number {
-  if (file.tokenCount !== undefined) return Math.max(0, file.tokenCount);
+  if (file.tokenCount !== undefined) {
+    return Math.max(0, file.tokenCount);
+  }
   return estimateTokens(file.content);
 }
 
 function getExpectedPartCount(file: PackStrategyFile, maxTokensPerFile: number): number {
   const tokens = getEffectiveTokenCount(file);
-  if (tokens <= maxTokensPerFile) return 1;
+  if (tokens <= maxTokensPerFile) {
+    return 1;
+  }
   return Math.max(2, Math.ceil(tokens / Math.max(1, maxTokensPerFile)));
 }
 
 export function findOversizedFiles(
   files: PackStrategyFile[],
-  maxTokensPerFile: number
+  maxTokensPerFile: number,
 ): OversizedFileInfo[] {
-  if (maxTokensPerFile <= 0) return [];
+  if (maxTokensPerFile <= 0) {
+    return [];
+  }
   return files
     .map((file) => ({
       path: file.path,
@@ -84,9 +96,13 @@ export function findOversizedFiles(
 }
 
 export function splitContentByTokenBudget(content: string, maxTokensPerFile: number): string[] {
-  if (maxTokensPerFile <= 0) return [content];
+  if (maxTokensPerFile <= 0) {
+    return [content];
+  }
   const maxCharsPerChunk = Math.max(1, maxTokensPerFile * APPROX_CHARS_PER_TOKEN);
-  if (content.length <= maxCharsPerChunk) return [content];
+  if (content.length <= maxCharsPerChunk) {
+    return [content];
+  }
 
   const minBreakOffset = Math.floor(maxCharsPerChunk * MIN_BREAK_SCAN_RATIO);
   const chunks: string[] = [];
@@ -128,9 +144,11 @@ function toPartPath(path: string, partIndex: number, partCount: number): string 
 
 export function buildOversizedFilesWarning(
   oversizedFiles: OversizedFileInfo[],
-  maxTokensPerFile: number
+  maxTokensPerFile: number,
 ): string | null {
-  if (oversizedFiles.length === 0) return null;
+  if (oversizedFiles.length === 0) {
+    return null;
+  }
   const examples = oversizedFiles
     .slice(0, 3)
     .map((f) => `${f.path} (~${formatCompactTokenCount(f.tokenCount)})`)
@@ -146,19 +164,19 @@ export function buildOversizedFilesWarning(
 
 export function splitOversizedFilesForPacking(
   files: PackStrategyFile[],
-  maxTokensPerFile: number
+  maxTokensPerFile: number,
 ): PackStrategyResult {
   const advisoryMaxTokensPerFile = Math.max(1, maxTokensPerFile);
   const oversizedFiles = findOversizedFiles(files, advisoryMaxTokensPerFile);
 
   if (oversizedFiles.length === 0) {
     return {
-      files,
-      oversizedFiles,
-      warnings: [],
       advisoryMaxTokensPerFile,
-      splitFileCount: 0,
+      files,
       generatedPartCount: 0,
+      oversizedFiles,
+      splitFileCount: 0,
+      warnings: [],
     };
   }
 
@@ -185,37 +203,41 @@ export function splitOversizedFilesForPacking(
 
     for (let i = 0; i < chunks.length; i++) {
       transformedFiles.push({
-        path: toPartPath(file.path, i, chunks.length),
         content: chunks[i],
+        path: toPartPath(file.path, i, chunks.length),
       });
     }
   }
 
   const warnings: string[] = [];
   const oversizedWarning = buildOversizedFilesWarning(oversizedFiles, advisoryMaxTokensPerFile);
-  if (oversizedWarning) warnings.push(oversizedWarning);
+  if (oversizedWarning) {
+    warnings.push(oversizedWarning);
+  }
   if (splitFileCount > 0) {
     warnings.push(
-      `Auto-balance enabled: split ${splitFileCount} oversized file(s) into ${generatedPartCount} part(s) to better balance pack sizes.`
+      `Auto-balance enabled: split ${splitFileCount} oversized file(s) into ${generatedPartCount} part(s) to better balance pack sizes.`,
     );
   }
 
   return {
-    files: transformedFiles,
-    oversizedFiles,
-    warnings,
     advisoryMaxTokensPerFile,
-    splitFileCount,
+    files: transformedFiles,
     generatedPartCount,
+    oversizedFiles,
+    splitFileCount,
+    warnings,
   };
 }
 
 export function forecastSplitPartCounts(
   files: PackStrategyFile[],
-  maxTokensPerFile: number
+  maxTokensPerFile: number,
 ): Map<string, number> {
   const partCounts = new Map<string, number>();
-  if (maxTokensPerFile <= 0) return partCounts;
+  if (maxTokensPerFile <= 0) {
+    return partCounts;
+  }
 
   for (const file of files) {
     const expected = getExpectedPartCount(file, maxTokensPerFile);
@@ -230,7 +252,7 @@ export function forecastSplitPartCounts(
 export function evaluatePerPackAdvisory(
   totalTokens: number,
   numPacks: number,
-  advisoryMaxTokensPerFile: number
+  advisoryMaxTokensPerFile: number,
 ): PerPackAdvisoryStatus {
   const safePacks = Math.max(1, numPacks);
   const safeAdvisoryMax = Math.max(1, advisoryMaxTokensPerFile);
@@ -238,8 +260,11 @@ export function evaluatePerPackAdvisory(
   const utilization = avgTokensPerPack / safeAdvisoryMax;
 
   let level: PerPackAdvisoryStatus["level"] = "ok";
-  if (utilization >= 1) level = "danger";
-  else if (utilization >= ADVISORY_WARN_RATIO) level = "warn";
+  if (utilization >= 1) {
+    level = "danger";
+  } else if (utilization >= ADVISORY_WARN_RATIO) {
+    level = "warn";
+  }
 
   const message =
     level === "danger"
@@ -249,10 +274,10 @@ export function evaluatePerPackAdvisory(
         : "Within advisory: average tokens per pack are under the recommended per-file budget.";
 
   return {
-    avgTokensPerPack,
     advisoryMaxTokensPerFile: safeAdvisoryMax,
-    utilization,
+    avgTokensPerPack,
     level,
     message,
+    utilization,
   };
 }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -174,6 +174,14 @@ describe("stripComments", () => {
       expect(result).toContain("b;");
       expect(result).not.toContain("outer");
     });
+
+    it("should keep comment markers inside quoted strings", () => {
+      const input = `const a = 'http://example.com';\nconst b = "https://example.com/path"; // real`;
+      const result = stripComments(input, "ts");
+      expect(result).toContain("http://example.com");
+      expect(result).toContain("https://example.com/path");
+      expect(result).not.toContain("real");
+    });
   });
 
   describe("hash-comment languages", () => {
@@ -255,6 +263,21 @@ describe("stripComments", () => {
       const result = stripComments("local x = 1 -- comment", "lua");
       expect(result).not.toContain("-- comment");
       expect(result).toContain("local x = 1");
+    });
+
+    it("should keep -- inside SQL single-quoted strings with escaped quotes", () => {
+      const input = "SELECT 'it''s -- text' AS t; -- real comment\nSELECT 1;";
+      const result = stripComments(input, "sql");
+      expect(result).toContain("'it''s -- text'");
+      expect(result).toContain("SELECT 1;");
+      expect(result).not.toContain("real comment");
+    });
+
+    it("should keep -- inside SQL double-quoted strings", () => {
+      const input = 'SELECT "col--name" FROM t; -- trailing comment';
+      const result = stripComments(input, "sql");
+      expect(result).toContain('"col--name"');
+      expect(result).not.toContain("trailing comment");
     });
   });
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -27,34 +27,36 @@ export function formatFileSize(bytes: number): string {
 
 export function getFileIcon(extension: string): string {
   const iconMap: Record<string, string> = {
+    bash: "shell",
+    css: "css",
+    go: "go",
+    html: "html",
+    js: "javascript",
+    json: "json",
+    jsx: "react",
+    md: "markdown",
+    py: "python",
+    rs: "rust",
+    sh: "shell",
+    toml: "toml",
     ts: "typescript",
     tsx: "react",
-    js: "javascript",
-    jsx: "react",
-    rs: "rust",
-    py: "python",
-    go: "go",
-    md: "markdown",
-    json: "json",
-    css: "css",
-    html: "html",
-    toml: "toml",
+    txt: "text",
     yaml: "yaml",
     yml: "yaml",
-    sh: "shell",
-    bash: "shell",
-    txt: "text",
   };
   return iconMap[extension.toLowerCase()] ?? "file";
 }
 
 export function debounce<T extends (...args: unknown[]) => unknown>(
   fn: T,
-  delay: number
+  delay: number,
 ): (...args: Parameters<T>) => void {
   let timer: ReturnType<typeof setTimeout> | null = null;
   return (...args: Parameters<T>) => {
-    if (timer) clearTimeout(timer);
+    if (timer) {
+      clearTimeout(timer);
+    }
     timer = setTimeout(() => fn(...args), delay);
   };
 }
@@ -84,9 +86,13 @@ function findCommentStart(line: string): number {
     const c = line[i];
     // A quote is escaped when preceded by an odd number of backslashes
     const isEscaped = countPrecedingBackslashes(line, i) % 2 === 1;
-    if (c === "'" && !inDouble && !isEscaped) inSingle = !inSingle;
-    else if (c === '"' && !inSingle && !isEscaped) inDouble = !inDouble;
-    else if (c === "#" && !inSingle && !inDouble) return i;
+    if (c === "'" && !inDouble && !isEscaped) {
+      inSingle = !inSingle;
+    } else if (c === '"' && !inSingle && !isEscaped) {
+      inDouble = !inDouble;
+    } else if (c === "#" && !inSingle && !inDouble) {
+      return i;
+    }
   }
   return -1;
 }
@@ -199,7 +205,9 @@ export function stripComments(content: string, extension: string): string {
       .split("\n")
       .map((line, index) => {
         // Preserve shebang on first line
-        if (index === 0 && line.startsWith("#!")) return line;
+        if (index === 0 && line.startsWith("#!")) {
+          return line;
+        }
         const commentStart = findCommentStart(line);
         return commentStart === -1 ? line : line.slice(0, commentStart).trimEnd();
       })
@@ -216,7 +224,7 @@ export function stripComments(content: string, extension: string): string {
       // def/class docstrings: triple-quoted string on the line(s) after a def/class colon
       result = result.replace(
         /((?:^|\n)[ \t]*(?:def|class)\b[^\n]*:\s*\n[ \t]*)("""[\s\S]*?"""|'''[\s\S]*?''')/g,
-        "$1"
+        "$1",
       );
     }
 
@@ -252,7 +260,9 @@ export function reduceWhitespace(content: string, extension?: string, filePath?:
     .split("\n")
     .map((line) => {
       const trimmed = line.trimEnd();
-      if (preserveIndentation) return trimmed;
+      if (preserveIndentation) {
+        return trimmed;
+      }
       // Fully left-align in whitespace-insensitive formats to maximize token savings.
       return trimmed.trimStart();
     })
@@ -264,7 +274,7 @@ export function reduceWhitespace(content: string, extension?: string, filePath?:
 export function minifyMarkdown(
   content: string,
   stripHeadings: boolean,
-  stripBlockquotes: boolean
+  stripBlockquotes: boolean,
 ): string {
   let result = content;
 
@@ -277,7 +287,7 @@ export function minifyMarkdown(
   // Strip block HTML tags and their content (handles nested tags better than balanced matching)
   result = result.replace(
     /<(div|details|summary|table|thead|tbody|tr|td|th)[^>]*>[\s\S]*?<\/\1>/gi,
-    ""
+    "",
   );
   // Strip void/self-closing tags
   result = result.replace(/<(img|br|hr)[^>]*\/?>/gi, "");

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,5 +9,5 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <ErrorBoundary>
       <App />
     </ErrorBoundary>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/workers/tokenizer.worker.ts
+++ b/src/workers/tokenizer.worker.ts
@@ -5,7 +5,9 @@ const encodingCache = new Map<string, ReturnType<typeof getEncoding>>();
 
 function getEncoder(encoding: TiktokenEncoding) {
   const cached = encodingCache.get(encoding);
-  if (cached) return cached;
+  if (cached) {
+    return cached;
+  }
   const enc = getEncoding(encoding);
   encodingCache.set(encoding, enc);
   return enc;
@@ -27,7 +29,7 @@ self.onmessage = (event: MessageEvent<WorkerMessage>) => {
       }
     });
 
-    const result: WorkerResult = { type: "result", requestId, results };
+    const result: WorkerResult = { requestId, results, type: "result" };
     self.postMessage(result);
   }
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,25 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true,
     "jsx": "react-jsx",
-    "strict": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "noFallthroughCasesInSwitch": true,
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ESNext",
+    "useDefineForClassFields": true
   },
-  "include": ["src"],
   "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"],
+  "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "composite": true,
-    "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
     "strict": true
   },
   "include": ["vite.config.ts"]


### PR DESCRIPTION
# GPT Codex 5.3

Implemented both fixes in [src/App.tsx](src/App.tsx).

1. Preview spinner stuck forever
- Root cause: `FilePreview` depends on `onLoadContent`, and `loadFileContent` was recreated each render. That caused effect cleanup cancellation before `isLoading` could be reset.
- Fix: made `loadFileContent` stable with `useCallback` at [src/App.tsx:397](src/App.tsx:397).

2. Bug report download not saving
- Fix: changed bug report export to the same pattern as pack “Export All” flow:
  - pick a folder via `open({ directory: true })`
  - `authorize_export_directory`
  - create filename and `join(folder, filename)`
  - write via `write_file_content`
- Updated at [src/App.tsx:593](src/App.tsx:593) and imports at [src/App.tsx:1](src/App.tsx:1).

Validation run:
- `bun test` passed.
- `bun run vite:build` passed.

Note: your working tree already had unrelated modifications (`package.json`, `tsconfig.json`, `tsconfig.node.json`, `src-tauri/Cargo.lock`) before this; I only changed `src/App.tsx`.

Applied a second round of fixes for both issues.

Changes made:

1. Preview spinner deadlock fix
- Reworked preview load effect to remove the `inFlight` cancellation pattern that can get stuck in React dev/effect double-run.
- `FilePreview` now:
  - sets loading false on cache hit,
  - starts one load path per effect run,
  - only clears spinner from the currently alive run.
- File: [FilePreview.tsx](src/components/FilePreview.tsx)

2. Bug report export flow switched back to save-file dialog
- Reverted from folder picker to `save(...)` dialog.
- Uses same write sequence as the working single-pack save:
  - `save` -> `dirname` -> `authorize_export_directory` -> `write_file_content`.
- File: [App.tsx](src/App.tsx)

3. Added debug logging for diagnosis
- Preview logs now include start/cache-hit/done/error.
- Bug report export logs now include start/cancel/success/fail.
- Preview file read logs now include start/success/fail from app side.
- Files: [App.tsx](src/App.tsx), [FilePreview.tsx](src/components/FilePreview.tsx)

Validation:
- `bun test` passed.
- `bun run vite:build` passed.

Please retry and export logs again.  
If spinner still hangs, send the lines containing `preview-read` and `[preview]` from the generated bug report; those should pinpoint whether the Tauri read is hanging or failing fast.

Implemented both requests.

- Removed the per-pack individual `Save` action from the output panel. Only `Export All` remains in [OutputPreview.tsx](src/components/OutputPreview.tsx:63) and [OutputPreview.tsx](src/components/OutputPreview.tsx:276).
- Fixed the AST dead-code bug that was dropping legitimate TSX code:
  - `.tsx` now uses the TSX grammar (not TS) in [ast.rs](src-tauri/src/commands/ast.rs:5).
  - Reachability now includes JSX identifiers in reference collection in [ast.rs](src-tauri/src/commands/ast.rs:111).
  - BFS is now seeded from entry-file references (important when entry file has no top-level declarations) in [ast.rs](src-tauri/src/commands/ast.rs:252).
  - Frontend stripper now preserves `export default Identifier;` symbols in [ast-reachability.ts](src/lib/ast-reachability.ts:16).

TDD/regression coverage added:

- New frontend tests for default-export identifier preservation:
  - [ast-reachability.test.ts](src/lib/ast-reachability.test.ts:97)
  - [ast-reachability.test.ts](src/lib/ast-reachability.test.ts:108)
- New backend integration-style AST test reproducing your `main/App/LimitIndicator` graph:
  - [ast.rs](src-tauri/src/commands/ast.rs:442)

Validation run:

- `bun test` passed (`130 pass, 0 fail`)
- `cargo test --manifest-path src-tauri/Cargo.toml` passed (`68 pass, 0 fail`)
- `bun run vite:build` passed

Next step:
1. Re-test your exact `main.tsx` + `App.tsx` + `LimitIndicator.tsx` case with AST enabled and entry point set to `main.tsx`.

Implemented all 4 requested changes.

1. Out-of-date pack UX
- Added pack-input fingerprinting and stale detection in [App.tsx](src/App.tsx#L67).
- When selection/options/model change after a pack, the button now:
  - switches to amber,
  - changes label to `Re-Pack N Files`,
  - shows an explicit “Output is out of date” warning.
- Relevant logic/UI: [App.tsx](src/App.tsx#L353), [App.tsx](src/App.tsx#L1022).

2. Removed `Copy + Prompt` and `Copy Pack`
- Removed both copy actions and prompt builder UI from output preview.
- `Export`/`Export All` remains.
- Updated in [OutputPreview.tsx](src/components/OutputPreview.tsx#L52).

3. Num-packs default behavior (1..5 => max, >5 => 5)
- Added defaulting behavior:
  - 1 selected file => slider auto-defaults to 1
  - 5 selected files => auto-defaults to 5
  - 6+ selected files => auto-defaults to 5
- Added manual override behavior: once user changes the slider, auto-defaulting stops (except hard cap).
- Logic in [App.tsx](src/App.tsx#L713), [App.tsx](src/App.tsx#L997).

4. New dev doc for macOS build/sign/notarize
- Added [macos-build-signing.md](docs/macos-build-signing.md).
- Includes:
  - prerequisites,
  - cert identity setup,
  - notarization env options (API key or Apple ID/app-specific password),
  - repo-accurate build commands (`bun run tauri build --target ...`),
  - verification and troubleshooting commands.

Also updated README feature bullets for current behavior in [README.md](README.md#L20).

Validation run:
- `bun test` passed.
- `bun run vite:build` passed.

Online references used for “up to date” check:
- [Tauri v2 prerequisites](https://v2.tauri.app/start/prerequisites/)
- [Tauri v2 macOS signing/notarization](https://v2.tauri.app/distribute/sign/macos/)
- [Tauri CLI build targets (universal-apple-darwin)](https://docs.rs/crate/tauri-cli/latest/source/README.md)
- [Apple app-specific passwords](https://support.apple.com/en-ca/102654)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive macOS build & signing guide for Tauri v2.
  * README updated to remove individual-pack export option (now "Export all packs in one folder").

* **New Features**
  * Pack out-of-date indicator with Re‑Pack workflow when selection/options change.
  * App-level logging with selectable log levels and debug event capture for previews and packs.

* **Improvements**
  * Simplified export UX to a single Export All control.
  * Updated file icon colors and menu/app naming to improve clarity.

* **Chores**
  * CI workflows and package metadata updated; stricter TypeScript compiler settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->